### PR TITLE
Job type deduction

### DIFF
--- a/boost/asynchronous/algorithm/geometry/parallel_geometry_intersection_of_x.hpp
+++ b/boost/asynchronous/algorithm/geometry/parallel_geometry_intersection_of_x.hpp
@@ -349,7 +349,7 @@ struct parallel_geometry_intersection_of_x_continuation_range_helper<Continuatio
 };
 }
 // version for ranges given as continuation => will return the range as continuation
-template <class Range, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value,boost::asynchronous::detail::callback_continuation<typename Range::return_type,Job> >::type
 parallel_geometry_intersection_of_x(Range range,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS

--- a/boost/asynchronous/algorithm/geometry/parallel_geometry_union_of_x.hpp
+++ b/boost/asynchronous/algorithm/geometry/parallel_geometry_union_of_x.hpp
@@ -344,7 +344,7 @@ struct parallel_geometry_union_of_x_continuation_range_helper<Continuation,Job,
 };
 }
 // version for ranges given as continuation => will return the range as continuation
-template <class Range, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value,boost::asynchronous::detail::callback_continuation<typename Range::return_type,Job> >::type
 parallel_geometry_union_of_x(Range range,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS

--- a/boost/asynchronous/algorithm/if_else.hpp
+++ b/boost/asynchronous/algorithm/if_else.hpp
@@ -201,7 +201,7 @@ struct else_if_continuation_helper :
 
 }
 
-template <class Continuation, class IfClause, class ThenClause,class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Continuation, class IfClause, class ThenClause,class Job=typename Continuation::job_type>
 boost::asynchronous::detail::callback_continuation<std::tuple<bool,typename Continuation::return_type>,Job>
 if_(Continuation cont,IfClause if_clause, ThenClause then_clause,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS

--- a/boost/asynchronous/algorithm/invoke.hpp
+++ b/boost/asynchronous/algorithm/invoke.hpp
@@ -118,7 +118,7 @@ private:
 };
 }
 // Notice: return value of Continuation must have a default-ctor
-template <class Continuation, class Func, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Continuation, class Func, class Job=typename Continuation::job_type>
 auto invoke(Continuation c,Func func,
  #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS
             const std::string& task_name, std::size_t prio=0

--- a/boost/asynchronous/algorithm/parallel_all_of.hpp
+++ b/boost/asynchronous/algorithm/parallel_all_of.hpp
@@ -120,7 +120,7 @@ struct parallel_all_of_continuation_range_helper: public boost::asynchronous::co
 };
 
 }
-template <class Range, class Func, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class Func, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value,boost::asynchronous::detail::callback_continuation<bool,Job> >::type
 parallel_all_of(Range range,Func func,long cutoff,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS

--- a/boost/asynchronous/algorithm/parallel_any_of.hpp
+++ b/boost/asynchronous/algorithm/parallel_any_of.hpp
@@ -120,7 +120,7 @@ struct parallel_any_of_continuation_range_helper: public boost::asynchronous::co
 };
 
 }
-template <class Range, class Func, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class Func, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value,boost::asynchronous::detail::callback_continuation<bool,Job> >::type
 parallel_any_of(Range range,Func func,long cutoff,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS

--- a/boost/asynchronous/algorithm/parallel_copy.hpp
+++ b/boost/asynchronous/algorithm/parallel_copy.hpp
@@ -316,7 +316,7 @@ struct parallel_copy_continuation_range_helper<Continuation, ResultIterator, Job
 };
 }
 
-template <class Range, class ResultIterator, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class ResultIterator, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value,boost::asynchronous::detail::callback_continuation<typename Range::return_type,Job> >::type
 parallel_copy(Range range,ResultIterator out,long cutoff,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS

--- a/boost/asynchronous/algorithm/parallel_count.hpp
+++ b/boost/asynchronous/algorithm/parallel_count.hpp
@@ -505,7 +505,7 @@ struct parallel_count_continuation_range_helper<Continuation,Func,Job,
 };
 }
 
-template <class Range, class Func, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class Func, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value, boost::asynchronous::detail::continuation<long, Job>>::type
 parallel_count_if(Range range,Func func,long cutoff,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS
@@ -519,7 +519,7 @@ parallel_count_if(Range range,Func func,long cutoff,
              (range,std::move(func),cutoff,task_name,prio));
 }
 
-template <class Range, class T, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class T, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value, boost::asynchronous::detail::continuation<long, Job>>::type
 parallel_count(Range range,T const& value,long cutoff,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS

--- a/boost/asynchronous/algorithm/parallel_extremum.hpp
+++ b/boost/asynchronous/algorithm/parallel_extremum.hpp
@@ -82,7 +82,7 @@ auto parallel_extremum(Range const& range, Comparison c,long cutoff,
 
 
 // Continuations
-template <class Range, class Comparison, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class Comparison, class Job=typename Range::job_type>
 auto parallel_extremum(Range range, Comparison c, long cutoff,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS
                        const std::string& task_name, std::size_t prio=0, typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value>::type* =0)

--- a/boost/asynchronous/algorithm/parallel_fill.hpp
+++ b/boost/asynchronous/algorithm/parallel_fill.hpp
@@ -78,7 +78,7 @@ parallel_fill(const Range& range, const Value& value, long cutoff,
 }
 
 // Continuations
-template <class Range, class Value, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class Value, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value, boost::asynchronous::detail::callback_continuation<typename Range::return_type, Job>>::type
 parallel_fill(Range range, const Value& value, long cutoff,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS

--- a/boost/asynchronous/algorithm/parallel_find_all.hpp
+++ b/boost/asynchronous/algorithm/parallel_find_all.hpp
@@ -490,7 +490,7 @@ struct parallel_find_all_continuation_range_helper<Continuation,Func,ReturnRange
 };
 }
 
-template <class Range, class Func, class ReturnRange=typename Range::return_type, class Job=typename BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class Func, class ReturnRange=typename Range::return_type, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value, boost::asynchronous::detail::callback_continuation<ReturnRange, Job>>::type
 parallel_find_all(Range range,Func func,long cutoff,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS

--- a/boost/asynchronous/algorithm/parallel_find_end.hpp
+++ b/boost/asynchronous/algorithm/parallel_find_end.hpp
@@ -227,7 +227,7 @@ struct parallel_find_end_range_helper: public boost::asynchronous::continuation_
 };
 }
 // version for 2nd range returned as continuation
-template <class Iterator1,class Range, class Func, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Iterator1,class Range, class Func, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value,boost::asynchronous::detail::callback_continuation<Iterator1,Job> >::type
 parallel_find_end(Iterator1 beg1, Iterator1 end1,Range range,Func func,long cutoff,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS

--- a/boost/asynchronous/algorithm/parallel_find_first_of.hpp
+++ b/boost/asynchronous/algorithm/parallel_find_first_of.hpp
@@ -196,7 +196,7 @@ struct parallel_find_first_of_range_helper: public boost::asynchronous::continua
 };
 }
 // version for 2nd range returned as continuation
-template <class Iterator1,class Range, class Func, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Iterator1,class Range, class Func, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value,boost::asynchronous::detail::callback_continuation<Iterator1,Job> >::type
 parallel_find_first_of(Iterator1 beg1, Iterator1 end1,Range range,Func func,long cutoff,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS

--- a/boost/asynchronous/algorithm/parallel_flatten.hpp
+++ b/boost/asynchronous/algorithm/parallel_flatten.hpp
@@ -333,7 +333,7 @@ parallel_flatten(
 template <
     class Continuation,
     class Result        = std::vector<typename boost::asynchronous::detail::container_traits<typename boost::asynchronous::detail::container_traits<typename Continuation::return_type>::value_type>::value_type>,
-    class Job           = BOOST_ASYNCHRONOUS_DEFAULT_JOB,
+    class Job           = typename Continuation::job_type,
     class OffsetStorage = std::vector<typename boost::asynchronous::detail::container_traits<typename boost::asynchronous::detail::container_traits<typename Continuation::return_type>::value_type>::size_type>
 >
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Continuation>::value, boost::asynchronous::detail::callback_continuation<Result, Job>>::type

--- a/boost/asynchronous/algorithm/parallel_for.hpp
+++ b/boost/asynchronous/algorithm/parallel_for.hpp
@@ -512,7 +512,7 @@ struct parallel_for_continuation_range_helper<Continuation,Func,Job,
     std::size_t prio_;
 };
 }
-template <class Range, class Func, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class Func, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value,boost::asynchronous::detail::callback_continuation<typename Range::return_type,Job> >::type
 parallel_for(Range range,Func func,long cutoff,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS

--- a/boost/asynchronous/algorithm/parallel_generate.hpp
+++ b/boost/asynchronous/algorithm/parallel_generate.hpp
@@ -76,7 +76,7 @@ parallel_generate(const Range& range, Func func, long cutoff,
 }
 
 // Continuations
-template <class Range, class Func, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class Func, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value, boost::asynchronous::detail::callback_continuation<typename Range::return_type, Job>>::type
 parallel_generate(Range range, Func func, long cutoff,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS

--- a/boost/asynchronous/algorithm/parallel_inclusive_scan.hpp
+++ b/boost/asynchronous/algorithm/parallel_inclusive_scan.hpp
@@ -118,7 +118,7 @@ parallel_inclusive_scan(Range&& range,T init,Func f,long cutoff,
 }
 
 // version for ranges given as continuation => will return the range as continuation
-template <class Range, class T, class Func, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class T, class Func, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value,
                           boost::asynchronous::detail::callback_continuation<typename Range::return_type,Job> >::type
 parallel_inclusive_scan(Range range,T init,Func f,long cutoff,

--- a/boost/asynchronous/algorithm/parallel_inner_product.hpp
+++ b/boost/asynchronous/algorithm/parallel_inner_product.hpp
@@ -718,7 +718,7 @@ template <class Continuation1,
                             )
                         )
                     ),
-          class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+          class Job=typename std::conditional<std::is_same<typename Continuation1::job_type, typename Continuation2::job_type>::value, typename Continuation1::job_type, BOOST_ASYNCHRONOUS_DEFAULT_JOB>::type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Continuation1>::value &&
                             boost::asynchronous::detail::has_is_continuation_task<Continuation2>::value,
                             boost::asynchronous::detail::callback_continuation<T, Job>>::type
@@ -759,7 +759,7 @@ template <class Continuation1,
                             )
                         )
                     ),
-          class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+          class Job=typename std::conditional<std::is_same<typename Continuation1::job_type, typename Continuation2::job_type>::value, typename Continuation1::job_type, BOOST_ASYNCHRONOUS_DEFAULT_JOB>::type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Continuation1>::value &&
                             boost::asynchronous::detail::has_is_continuation_task<Continuation2>::value,
                             boost::asynchronous::detail::callback_continuation<T, Job>>::type

--- a/boost/asynchronous/algorithm/parallel_move.hpp
+++ b/boost/asynchronous/algorithm/parallel_move.hpp
@@ -315,7 +315,7 @@ struct parallel_move_continuation_range_helper<Continuation, ResultIterator, Job
 };
 }
 
-template <class Range, class ResultIterator, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class ResultIterator, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value,boost::asynchronous::detail::callback_continuation<typename Range::return_type,Job> >::type
 parallel_move(Range range,ResultIterator out,long cutoff,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS

--- a/boost/asynchronous/algorithm/parallel_none_of.hpp
+++ b/boost/asynchronous/algorithm/parallel_none_of.hpp
@@ -120,7 +120,7 @@ struct parallel_none_of_continuation_range_helper: public boost::asynchronous::c
 };
 
 }
-template <class Range, class Func, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class Func, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value,boost::asynchronous::detail::callback_continuation<bool,Job> >::type
 parallel_none_of(Range range,Func func,long cutoff,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS

--- a/boost/asynchronous/algorithm/parallel_partial_sum.hpp
+++ b/boost/asynchronous/algorithm/parallel_partial_sum.hpp
@@ -62,7 +62,7 @@ parallel_partial_sum(Range&& range,Func f,long cutoff,
 }
 
 // version for ranges given as continuation => will return the range as continuation
-template <class Range, class Func, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class Func, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value,
                           boost::asynchronous::detail::callback_continuation<typename Range::return_type,Job> >::type
 parallel_partial_sum(Range range,Func f,long cutoff,

--- a/boost/asynchronous/algorithm/parallel_reduce.hpp
+++ b/boost/asynchronous/algorithm/parallel_reduce.hpp
@@ -568,7 +568,7 @@ struct parallel_reduce_continuation_range_helper<Continuation,Func,Func2,ReturnT
 #define _FUNC_RETURN_TYPE decltype(func(_VALUE, _VALUE))
 #define _FUNC_RETURN_TYPE2 decltype(func2(_VALUE, _VALUE))
 
-template <class Range, class Func, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class Func, class Job=typename Range::job_type>
 auto parallel_reduce(Range range,Func func,long cutoff,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS
                      const std::string& task_name, std::size_t prio=0)
@@ -583,7 +583,7 @@ auto parallel_reduce(Range range,Func func,long cutoff,
 }
 
 // version with 2 functors
-template <class Range, class Func, class Func2, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class Func, class Func2, class Job=typename Range::job_type>
 auto parallel_reduce(Range range,Func func,Func2 func2,long cutoff,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS
                     const std::string& task_name, std::size_t prio=0)

--- a/boost/asynchronous/algorithm/parallel_replace.hpp
+++ b/boost/asynchronous/algorithm/parallel_replace.hpp
@@ -92,7 +92,7 @@ parallel_replace(Range&& range, T const& old_value, T const& new_value, long cut
 }
 
 // versions with continuation
-template <class Range, class T,class Func, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class T,class Func, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value,
                           boost::asynchronous::detail::callback_continuation<typename Range::return_type,Job> >::type
 parallel_replace_if(Range range, Func func, T const& new_value, long cutoff,
@@ -111,7 +111,7 @@ parallel_replace_if(Range range, Func func, T const& new_value, long cutoff,
     };
     return boost::asynchronous::parallel_for<Range,decltype(l),Job>(std::move(range),std::move(l),cutoff,task_name,prio);
 }
-template <class Range, class T, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class T, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value,
                           boost::asynchronous::detail::callback_continuation<typename Range::return_type,Job> >::type
 parallel_replace(Range range, T const& old_value, T const& new_value, long cutoff,

--- a/boost/asynchronous/algorithm/parallel_replace_copy.hpp
+++ b/boost/asynchronous/algorithm/parallel_replace_copy.hpp
@@ -99,7 +99,7 @@ struct parallel_replace_copy_if_continuation_helper: public boost::asynchronous:
 };
 }
 
-template <class Range, class Iterator2, class Func, class T, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class Iterator2, class Func, class T, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value,boost::asynchronous::detail::callback_continuation<Iterator2,Job> >::type
 parallel_replace_copy_if(Range range,Iterator2 beg2,Func func, T const& new_value, long cutoff,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS
@@ -196,7 +196,7 @@ struct parallel_replace_copy_continuation_helper: public boost::asynchronous::co
 };
 }
 
-template <class Range, class Iterator2, class T, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class Iterator2, class T, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value,boost::asynchronous::detail::callback_continuation<Iterator2,Job> >::type
 parallel_replace_copy(Range range,Iterator2 beg2, T const& old_value, T const& new_value, long cutoff,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS

--- a/boost/asynchronous/algorithm/parallel_reverse.hpp
+++ b/boost/asynchronous/algorithm/parallel_reverse.hpp
@@ -226,7 +226,7 @@ struct parallel_reverse_continuation_range_helper<Continuation,Job,
     std::size_t prio_;
 };
 }
-template <class Range, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value,boost::asynchronous::detail::callback_continuation<typename Range::return_type,Job> >::type
 parallel_reverse(Range range,long cutoff,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS

--- a/boost/asynchronous/algorithm/parallel_scan.hpp
+++ b/boost/asynchronous/algorithm/parallel_scan.hpp
@@ -553,7 +553,7 @@ struct parallel_scan_range_continuation_helper: public boost::asynchronous::cont
 };
 }
 // version for ranges given as continuation => will return the range as continuation
-template <class Range, class T, class Reduce, class Combine, class Scan, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class T, class Reduce, class Combine, class Scan, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value,
                           boost::asynchronous::detail::callback_continuation<typename Range::return_type,Job> >::type
 parallel_scan(Range range,T init,Reduce r, Combine c, Scan s,long cutoff,

--- a/boost/asynchronous/algorithm/parallel_search.hpp
+++ b/boost/asynchronous/algorithm/parallel_search.hpp
@@ -226,7 +226,7 @@ struct parallel_search_range_helper: public boost::asynchronous::continuation_ta
 };
 }
 // version for 2nd range returned as continuation
-template <class Iterator1,class Range, class Func, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Iterator1,class Range, class Func, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value,boost::asynchronous::detail::callback_continuation<Iterator1,Job> >::type
 parallel_search(Iterator1 beg1, Iterator1 end1,Range range,Func func,long cutoff,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS

--- a/boost/asynchronous/algorithm/parallel_sort.hpp
+++ b/boost/asynchronous/algorithm/parallel_sort.hpp
@@ -1291,7 +1291,7 @@ struct parallel_spreadsort_continuation_range_helper<Continuation,Func,Job,
 };
 #endif
 }
-template <class Range, class Func, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class Func, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value,boost::asynchronous::detail::callback_continuation<typename Range::return_type,Job> >::type
 parallel_sort(Range range,Func func,long cutoff,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS
@@ -1303,7 +1303,7 @@ parallel_sort(Range range,Func func,long cutoff,
     return boost::asynchronous::top_level_callback_continuation_job<typename Range::return_type,Job>
             (boost::asynchronous::detail::parallel_sort_continuation_range_helper<Range,Func,Job>(range,std::move(func),cutoff,task_name,prio));
 }
-template <class Range, class Func, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class Func, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value,boost::asynchronous::detail::callback_continuation<typename Range::return_type,Job> >::type
 parallel_stable_sort(Range range,Func func,long cutoff,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS
@@ -1316,7 +1316,7 @@ parallel_stable_sort(Range range,Func func,long cutoff,
             (boost::asynchronous::detail::parallel_stable_sort_continuation_range_helper<Range,Func,Job>(range,std::move(func),cutoff,task_name,prio));
 }
 #ifdef BOOST_ASYNCHRONOUS_USE_BOOST_SPREADSORT
-template <class Range, class Func, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class Func, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value,boost::asynchronous::detail::callback_continuation<typename Range::return_type,Job> >::type
 parallel_spreadsort(Range range,Func func,long cutoff,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS
@@ -1624,7 +1624,7 @@ struct parallel_spreadsort_continuation_range_helper2<Continuation,Func,Job,
 };
 #endif
 }
-template <class Range, class Func, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class Func, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value,boost::asynchronous::detail::callback_continuation<typename Range::return_type,Job> >::type
 parallel_sort2(Range range,Func func,long cutoff,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS
@@ -1636,7 +1636,7 @@ parallel_sort2(Range range,Func func,long cutoff,
     return boost::asynchronous::top_level_callback_continuation_job<typename Range::return_type,Job>
             (boost::asynchronous::detail::parallel_sort_continuation_range_helper2<Range,Func,Job>(range,std::move(func),cutoff,task_name,prio));
 }
-template <class Range, class Func, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class Func, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value,boost::asynchronous::detail::callback_continuation<typename Range::return_type,Job> >::type
 parallel_stable_sort2(Range range,Func func,long cutoff,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS
@@ -1649,7 +1649,7 @@ parallel_stable_sort2(Range range,Func func,long cutoff,
             (boost::asynchronous::detail::parallel_stable_sort_continuation_range_helper2<Range,Func,Job>(range,std::move(func),cutoff,task_name,prio));
 }
 #ifdef BOOST_ASYNCHRONOUS_USE_BOOST_SPREADSORT
-template <class Range, class Func, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class Func, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value,boost::asynchronous::detail::callback_continuation<typename Range::return_type,Job> >::type
 parallel_spreadsort2(Range range,Func func,long cutoff,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS

--- a/boost/asynchronous/algorithm/parallel_sort_inplace.hpp
+++ b/boost/asynchronous/algorithm/parallel_sort_inplace.hpp
@@ -532,7 +532,7 @@ struct parallel_spreadsort_continuation_range_inplace_helper<Continuation,Func,J
 };
 #endif
 }
-template <class Range, class Func, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class Func, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value,boost::asynchronous::detail::callback_continuation<typename Range::return_type,Job> >::type
 parallel_sort_inplace(Range range,Func func,long cutoff,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS
@@ -544,7 +544,7 @@ parallel_sort_inplace(Range range,Func func,long cutoff,
     return boost::asynchronous::top_level_callback_continuation_job<typename Range::return_type,Job>
             (boost::asynchronous::detail::parallel_sort_continuation_range_inplace_helper<Range,Func,Job>(range,std::move(func),cutoff,task_name,prio));
 }
-template <class Range, class Func, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class Func, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value,boost::asynchronous::detail::callback_continuation<typename Range::return_type,Job> >::type
 parallel_stable_sort_inplace(Range range,Func func,long cutoff,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS
@@ -557,7 +557,7 @@ parallel_stable_sort_inplace(Range range,Func func,long cutoff,
             (boost::asynchronous::detail::parallel_stable_sort_continuation_range_inplace_helper<Range,Func,Job>(range,std::move(func),cutoff,task_name,prio));
 }
 #ifdef BOOST_ASYNCHRONOUS_USE_BOOST_SPREADSORT
-template <class Range, class Func, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class Func, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value,boost::asynchronous::detail::callback_continuation<typename Range::return_type,Job> >::type
 parallel_spreadsort_inplace(Range range,Func func,long cutoff,
 #ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS

--- a/boost/asynchronous/algorithm/parallel_stable_partition.hpp
+++ b/boost/asynchronous/algorithm/parallel_stable_partition.hpp
@@ -531,7 +531,7 @@ struct parallel_stable_partition_continuation_helper:
 }
 
 // version where the range is itself a continuation
-template <class Range, class Func, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class Func, class Job=typename Range::job_type>
 typename std::enable_if<
         boost::asynchronous::detail::has_is_continuation_task<Range>::value,
         boost::asynchronous::detail::callback_continuation<

--- a/boost/asynchronous/algorithm/parallel_unique.hpp
+++ b/boost/asynchronous/algorithm/parallel_unique.hpp
@@ -133,7 +133,7 @@ parallel_unique(Iterator beg, Iterator end,Func func,long cutoff,
 }
 
 // version for ranges returned as continuations
-template <class Range, class Func, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Range, class Func, class Job=typename Range::job_type>
 typename std::enable_if<boost::asynchronous::detail::has_is_continuation_task<Range>::value,
                         boost::asynchronous::detail::callback_continuation<typename Range::return_type,Job> >::type
 parallel_unique(Range range,Func func,long cutoff,
@@ -144,12 +144,12 @@ parallel_unique(Range range,Func func,long cutoff,
 #endif
 {
 
-    return boost::asynchronous::then(
+    return boost::asynchronous::then_job<Job>(
                  std::move(range),
                  [func,cutoff,task_name,prio](boost::asynchronous::expected<typename Range::return_type>&& r)mutable
                  {
                     auto res = std::make_shared<typename Range::return_type>(std::move(r.get()));
-                    return boost::asynchronous::then(
+                    return boost::asynchronous::then_job<Job>(
                             boost::asynchronous::parallel_unique
                                   <typename Range::return_type::iterator, Func, Job>
                                        (boost::begin(*res),boost::end(*res),func,cutoff,task_name,prio),

--- a/boost/asynchronous/algorithm/then.hpp
+++ b/boost/asynchronous/algorithm/then.hpp
@@ -211,7 +211,7 @@ struct then_helper : public boost::asynchronous::continuation_task<typename Trai
 
 } // namespace detail
 
-template <class Continuation, class Functor, class Job=BOOST_ASYNCHRONOUS_DEFAULT_JOB>
+template <class Continuation, class Functor, class Job = typename Continuation::job_type>
 typename std::enable_if<
     boost::asynchronous::detail::has_is_continuation_task<Continuation>::value,
     boost::asynchronous::detail::callback_continuation<
@@ -232,6 +232,29 @@ then(Continuation continuation, Functor func,
             boost::asynchronous::detail::move_where_possible(func),
             task_name
         )
+    );
+}
+
+// This is a special version of boost::asynchronous::then that allows algorithm implementations to pass in a job type without sacrificing deduction of the continuation and functor types
+template <class Job, class Continuation, class Functor>
+typename std::enable_if<
+    boost::asynchronous::detail::has_is_continuation_task<Continuation>::value,
+    boost::asynchronous::detail::callback_continuation<
+        typename boost::asynchronous::detail::then_traits<Continuation, Functor>::ReturnType,
+        Job
+    >
+>::type
+then_job(Continuation continuation, Functor func,
+#ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS
+             const std::string& task_name)
+#else
+             const std::string& task_name="")
+#endif
+{
+    return boost::asynchronous::then<Continuation, Functor, Job>(
+        boost::asynchronous::detail::move_where_possible(continuation),
+        boost::asynchronous::detail::move_where_possible(func),
+        task_name
     );
 }
 

--- a/boost/asynchronous/detail/continuation_impl.hpp
+++ b/boost/asynchronous/detail/continuation_impl.hpp
@@ -458,6 +458,7 @@ struct continuation
 {
     typedef int is_continuation_task;
     typedef Return return_type;
+    typedef Job job_type;
     // metafunction telling if we are future or expected based sind
     template <class T>
     struct continuation_args
@@ -688,6 +689,7 @@ struct callback_continuation
     typedef int is_continuation_task;
     typedef int is_callback_continuation_task;
     typedef Return return_type;
+    typedef Job job_type;
     // metafunction telling if we are future or expected based
     template <class T>
     struct continuation_args
@@ -1014,6 +1016,7 @@ struct continuation_as_seq
 {
     typedef int is_continuation_task;
     typedef Return return_type;
+    typedef Job job_type;
     // metafunction telling if we are future or expected based sind
     template <class T>
     struct continuation_args
@@ -1127,6 +1130,7 @@ struct callback_continuation_as_seq
     typedef int is_continuation_task;
     typedef int is_callback_continuation_task;
     typedef Return return_type;
+    typedef Job job_type;
     // metafunction telling if we are future or expected based
     template <class T>
     struct continuation_args


### PR DESCRIPTION
In their continuation forms, `boost::asynchronous::then` (and really all other algorithms) should try to maintain the job type that is given to them (this saves us from having to specify all the other template arguments manually).

The first commit exposes `job_type` (analogous to `result_type`) on continuation types, the second uses that whereever possible.

Additionally, `boost::asynchronous::then_job` is added to allow overriding the automatic job type deduction without having to specify the other template parameters (this is especially useful when implementing an algorithm that already allows the user to specify a job type - the `parallel_unique` implementation has been adapted accordingly).

The test cases, as far as I can tell, still pass. 

Untested:
* `test_asio_deadline_timer_single_thread.cpp` and `test_parallel_reduce2.cpp` appear to be broken in general
* `test_geometry_union_of_x.cpp` (wrong Boost.Geometry version)
* `test_parallel_quicksort.cpp` and `test_parallel_spreadsort.cpp` (no Boost.Sort)
* `test_scheduler_post.cpp` (no Intel TBB)