### PR TITLE
all_of, any_of, parallel_kmp

### DIFF
--- a/boost/asynchronous/algorithm/all_of.hpp
+++ b/boost/asynchronous/algorithm/all_of.hpp
@@ -1,0 +1,171 @@
+// Boost.Asynchronous library
+//  Copyright (C) Tobias Holl 2018
+//
+//  Use, modification and distribution is subject to the Boost
+//  Software License, Version 1.0.  (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// For more information, see http://www.boost.org
+
+#ifndef BOOST_ASYNCHRONOUS_ALL_OF_CONT_HPP
+#define BOOST_ASYNCHRONOUS_ALL_OF_CONT_HPP
+
+#include <atomic>
+#include <memory>
+#include <tuple>
+#include <type_traits>
+
+#include <boost/mpl/and.hpp>
+
+#include <boost/asynchronous/detail/continuation_impl.hpp>
+#include <boost/asynchronous/detail/job_type_from.hpp>
+#include <boost/asynchronous/detail/metafunctions.hpp>
+#include <boost/asynchronous/continuation_task.hpp>
+#include <boost/asynchronous/algorithm/detail/helpers.hpp>
+
+namespace boost
+{
+namespace asynchronous
+{
+
+namespace detail
+{
+
+template <typename ResultTuple>
+struct all_of_task_counter
+{
+    all_of_task_counter()
+        : task_count(std::tuple_size<ResultTuple>::value)
+    {}
+
+    ResultTuple         values;
+    std::atomic<size_t> task_count;
+};
+
+template <typename... Continuations>
+struct all_of_return_type
+{
+    // Replace void by boost::asynchronous::detail::void_wrapper, because void is not allowed in tuples
+    using type = std::tuple<typename boost::asynchronous::detail::wrap<typename Continuations::return_type>::type...>;
+};
+
+template <typename Job, typename... Continuations>
+struct all_of_helper : public boost::asynchronous::continuation_task<typename boost::asynchronous::detail::all_of_return_type<Continuations...>::type>
+{
+    using return_type = typename boost::asynchronous::detail::all_of_return_type<Continuations...>::type;
+    using task_counter_type = boost::asynchronous::detail::all_of_task_counter<return_type>;
+
+    all_of_helper(Continuations... continuations)
+        : boost::asynchronous::continuation_task<return_type>("boost::asynchronous::all_of(...)")
+        , continuations_(std::move(continuations)...)
+    {}
+
+    // Dispatch recursion
+    template <size_t Index>
+    typename std::enable_if<(Index > 0)>::type dispatch_next(std::shared_ptr<task_counter_type> task_counter, boost::asynchronous::continuation_result<return_type> task_res)
+    {
+        dispatch<Index>(task_counter, task_res);
+        dispatch_next<Index - 1>(task_counter, task_res);
+    }
+
+    template <size_t Index>
+    typename std::enable_if<(Index == 0)>::type dispatch_next(std::shared_ptr<task_counter_type> task_counter, boost::asynchronous::continuation_result<return_type> task_res)
+    {
+        dispatch<Index>(task_counter, task_res);
+        // End of recursion.
+    }
+
+    // Store a non-void result
+    template <size_t Index>
+    typename std::enable_if<
+        !std::is_same<typename std::tuple_element<Index, std::tuple<Continuations...>>::type::return_type, void>::value
+    >::type
+    dispatch(std::shared_ptr<task_counter_type> task_counter, boost::asynchronous::continuation_result<return_type> task_res)
+    {
+        std::get<Index>(continuations_).on_done(
+            [task_counter, task_res](std::tuple<boost::asynchronous::expected<typename std::tuple_element<Index, std::tuple<Continuations...>>::type::return_type>>&& args)
+            {
+                try
+                {
+                    std::get<Index>(task_counter->values) = std::move(std::get<0>(args).get());
+                    size_t remaining = --(task_counter->task_count);
+                    if (remaining == 0)
+                    {
+                        task_res.set_value(std::move(task_counter->values));
+                    }
+                }
+                catch (...)
+                {
+                    task_res.set_exception(std::current_exception());
+                }
+            }
+        );
+    }
+
+    // "Store" a void result
+    template <size_t Index>
+    typename std::enable_if<
+        std::is_same<typename std::tuple_element<Index, std::tuple<Continuations...>>::type::return_type, void>::value
+    >::type
+    dispatch(std::shared_ptr<task_counter_type> task_counter, boost::asynchronous::continuation_result<return_type> task_res)
+    {
+        std::get<Index>(continuations_).on_done(
+            [task_counter, task_res](std::tuple<boost::asynchronous::expected<typename std::tuple_element<Index, std::tuple<Continuations...>>::type::return_type>>&& args)
+            {
+                try
+                {
+                    std::get<0>(args).get();
+                    std::get<Index>(task_counter->values) = boost::asynchronous::detail::void_wrapper {};
+                    size_t remaining = --(task_counter->task_count);
+                    if (remaining == 0)
+                    {
+                        task_res.set_value(std::move(task_counter->values));
+                    }
+                }
+                catch (...)
+                {
+                    task_res.set_exception(std::current_exception());
+                }
+            }
+        );
+    }
+
+    void operator()()
+    {
+        boost::asynchronous::continuation_result<return_type> task_res = this->this_task_result();
+        auto task_counter = std::make_shared<task_counter_type>();
+
+        dispatch_next<sizeof...(Continuations) - 1>(task_counter, task_res);
+    }
+
+    std::tuple<Continuations...> continuations_;
+};
+
+} // namespace detail
+
+template <typename Job, typename... Continuations>
+typename std::enable_if<
+    boost::mpl::and_<boost::asynchronous::detail::has_is_continuation_task<Continuations>...>::type::value,
+    boost::asynchronous::detail::callback_continuation<
+        typename boost::asynchronous::detail::all_of_return_type<Continuations...>::type,
+        Job
+    >
+>::type
+all_of_job(Continuations... continuations)
+{
+    return boost::asynchronous::top_level_callback_continuation_job<typename boost::asynchronous::detail::all_of_return_type<Continuations...>::type, Job>(
+        boost::asynchronous::detail::all_of_helper<Job, Continuations...>(std::move(continuations)...)
+    );
+}
+
+template <typename... Continuations>
+auto all_of(Continuations... continuations)
+    -> decltype(all_of_job<typename boost::asynchronous::detail::job_type_from<Continuations...>::type, Continuations...>(std::move(continuations)...))
+{
+    return all_of_job<typename boost::asynchronous::detail::job_type_from<Continuations...>::type, Continuations...>(std::move(continuations)...);
+}
+
+} // namespace asynchronous
+} // namespace boost
+
+#endif // BOOST_ASYNCHRONOUS_ALL_OF_CONT_HPP

--- a/boost/asynchronous/algorithm/any_of.hpp
+++ b/boost/asynchronous/algorithm/any_of.hpp
@@ -1,0 +1,279 @@
+// Boost.Asynchronous library
+//  Copyright (C) Tobias Holl 2018
+//
+//  Use, modification and distribution is subject to the Boost
+//  Software License, Version 1.0.  (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// For more information, see http://www.boost.org
+
+#ifndef BOOST_ASYNCHRONOUS_ANY_OF_CONT_HPP
+#define BOOST_ASYNCHRONOUS_ANY_OF_CONT_HPP
+
+#include <limits>
+#include <memory>
+#include <tuple>
+#include <type_traits>
+
+#include <boost/mpl/contains.hpp>
+#include <boost/mpl/vector.hpp>
+#include <boost/variant.hpp>
+
+#include <boost/asynchronous/detail/continuation_impl.hpp>
+#include <boost/asynchronous/detail/job_type_from.hpp>
+#include <boost/asynchronous/detail/metafunctions.hpp>
+#include <boost/asynchronous/continuation_task.hpp>
+#include <boost/asynchronous/algorithm/detail/helpers.hpp>
+
+namespace boost
+{
+namespace asynchronous
+{
+
+// In all_of, it is simple enough to just return a tuple of values. However, any_of can only return one value, so there are a number of options that we can pursue:
+// Either, we use a variant type (like Boost.Variant) to encapsulate all the different possible return types. Unfortunately, there are use cases where we need to
+// know which of the continuations returned, even if multiple of them have the same return type. A better solution would be to store an index into a tuple, but if
+// the tuple contains large types with slow default constructors, we suffer a significant performance penalty just from creating the type. Additionally, std::tuple
+// only allows compile-time indexing - not the runtime indexing we need for any_of because the target index only becomes known when a continuation finishes.
+// We need some form of type erasure (either through Boost.Variant or Boost.Any) *and* the index of the finished continuation to provide the users with what they
+// need from any_of.
+// There is an additional complication with Boost.Variant because it may only contain *distinct* types, which we need to fix manually
+
+namespace detail
+{
+
+// Filter out non-distinct types, and void, from a boost::variant<Ts...>
+template <typename Complete, typename... Ts>
+struct distinct_variant_impl
+{
+    using type = Complete;
+};
+
+template <typename... Cs, typename T, typename... Ts>
+struct distinct_variant_impl<boost::variant<Cs...>, T, Ts...>
+{
+private:
+    // Iff T is not equal to any of Cs..., add it.
+    template <typename U>
+    static typename std::enable_if<
+        !boost::mpl::contains<typename boost::variant<Cs...>::types, typename std::remove_cv<U>::type>::type::value,
+        typename distinct_variant_impl<boost::variant<Cs..., typename std::remove_cv<U>::type>, Ts...>::type
+    >::type next();
+
+    template <typename U>
+    static typename std::enable_if<
+        boost::mpl::contains<typename boost::variant<Cs...>::types, typename std::remove_cv<U>::type>::type::value,
+        typename distinct_variant_impl<boost::variant<Cs...>, Ts...>::type
+    >::type next();
+
+public:
+    using type = decltype(next<T>());
+};
+
+
+template <typename... Cs, typename... Ts>
+struct distinct_variant_impl<boost::variant<Cs...>, void, Ts...>
+{
+    using type = typename distinct_variant_impl<boost::variant<Cs...>, Ts...>::type;
+};
+
+template <typename... Ts> struct distinct_variant;
+
+template <typename T, typename... Ts>
+struct distinct_variant<T, Ts...>
+{
+    using type = typename distinct_variant_impl<boost::variant<T>, Ts...>::type;
+};
+
+template <typename... Ts>
+struct distinct_variant<void, Ts...>
+{
+    using type = typename distinct_variant<Ts...>::type;
+};
+
+template <>
+struct distinct_variant<>
+{
+    // There were only void types - use void_wrapper as a dummy type.
+    using type = boost::variant<boost::asynchronous::detail::void_wrapper>;
+};
+
+} // namespace detail
+
+// The return type of any_of stores the index of the returning continuation, and a variant containing the actual value.
+template <typename... Types>
+struct any_of_result
+{
+    constexpr static size_t count = sizeof...(Types);
+
+    size_t index = std::numeric_limits<size_t>::max();
+    typename boost::asynchronous::detail::distinct_variant<Types...>::type value;
+};
+
+namespace detail
+{
+
+// The result storage. We want to fail with an exception if and only if all tasks failed, which is why we still need to store the full number of tasks
+template <typename Storage>
+struct any_of_task_counter
+{
+    any_of_task_counter()
+        : failures_remaining(Storage::count)
+    {}
+
+    Storage storage;
+    std::atomic<size_t> failures_remaining;
+    std::atomic_flag has_value;
+
+    template <size_t Index, typename T>
+    bool set(T&& t)
+    {
+        bool was_empty = !has_value.test_and_set();
+        if (was_empty)
+        {
+            storage.index = Index;
+            storage.value = std::forward<T>(t);
+        }
+        return was_empty;
+    }
+
+    template <size_t Index>
+    bool set()
+    {
+        bool was_empty = !has_value.test_and_set();
+        if (was_empty)
+            storage.index = Index;
+        return was_empty;
+    }
+};
+
+template <typename Job, typename... Continuations>
+struct any_of_helper : public boost::asynchronous::continuation_task<boost::asynchronous::any_of_result<typename Continuations::return_type...>>
+{
+    using return_type = boost::asynchronous::any_of_result<typename Continuations::return_type...>;
+    using task_counter_type = boost::asynchronous::detail::any_of_task_counter<return_type>;
+
+    any_of_helper(Continuations... continuations)
+        : boost::asynchronous::continuation_task<return_type>("boost::asynchronous::any_of(...)")
+        , continuations_(std::move(continuations)...)
+    {}
+
+    // Dispatch recursion
+    template <size_t Index>
+    typename std::enable_if<(Index > 0)>::type dispatch_next(std::shared_ptr<task_counter_type> task_counter, boost::asynchronous::continuation_result<return_type> task_res)
+    {
+        dispatch<Index>(task_counter, task_res);
+        dispatch_next<Index - 1>(task_counter, task_res);
+    }
+
+    template <size_t Index>
+    typename std::enable_if<(Index == 0)>::type dispatch_next(std::shared_ptr<task_counter_type> task_counter, boost::asynchronous::continuation_result<return_type> task_res)
+    {
+        dispatch<Index>(task_counter, task_res);
+        // End of recursion.
+    }
+
+    // Store a non-void result
+    template <size_t Index>
+    typename std::enable_if<
+        !std::is_same<typename std::tuple_element<Index, std::tuple<Continuations...>>::type::return_type, void>::value
+    >::type
+    dispatch(std::shared_ptr<task_counter_type> task_counter, boost::asynchronous::continuation_result<return_type> task_res)
+    {
+        std::get<Index>(continuations_).on_done(
+            [task_counter, task_res](std::tuple<boost::asynchronous::expected<typename std::tuple_element<Index, std::tuple<Continuations...>>::type::return_type>>&& args)
+            {
+                try
+                {
+                    bool done = task_counter->template set<Index>(std::move(std::get<0>(args).get()));
+                    if (done)
+                        task_res.set_value(std::move(task_counter->storage));
+                    // TODO: On completion, interrupt other continuations if possible
+                }
+                catch (...)
+                {
+                    size_t failures_remaining = --(task_counter->failures_remaining);
+                    if (failures_remaining == 0)
+                    {
+                        // If all tasks failed, pass the last exception down
+                        // TODO: Find a way to report all exceptions?
+                        task_res.set_exception(std::current_exception());
+                    }
+                }
+            }
+        );
+    }
+
+    // "Store" a void result
+    template <size_t Index>
+    typename std::enable_if<
+        std::is_same<typename std::tuple_element<Index, std::tuple<Continuations...>>::type::return_type, void>::value
+    >::type
+    dispatch(std::shared_ptr<task_counter_type> task_counter, boost::asynchronous::continuation_result<return_type> task_res)
+    {
+        std::get<Index>(continuations_).on_done(
+            [task_counter, task_res](std::tuple<boost::asynchronous::expected<typename std::tuple_element<Index, std::tuple<Continuations...>>::type::return_type>>&& args)
+            {
+                try
+                {
+                    std::get<0>(args).get();
+                    bool done = task_counter->template set<Index>();
+                    if (done)
+                        task_res.set_value(std::move(task_counter->storage));
+                    // TODO: On completion, interrupt other continuations if possible
+                }
+                catch (...)
+                {
+                    size_t failures_remaining = --(task_counter->failures_remaining);
+                    if (failures_remaining == 0)
+                    {
+                        // If all tasks failed, pass the last exception down
+                        // TODO: Find a way to report all exceptions?
+                        task_res.set_exception(std::current_exception());
+                    }
+                }
+            }
+        );
+    }
+
+    void operator()()
+    {
+        boost::asynchronous::continuation_result<return_type> task_res = this->this_task_result();
+        auto task_counter = std::make_shared<task_counter_type>();
+
+        dispatch_next<sizeof...(Continuations) - 1>(task_counter, task_res);
+    }
+
+    std::tuple<Continuations...> continuations_;
+};
+
+} // namespace detail
+
+// When using any_of, manage object lifetimes carefully - any_of may return a value before all continuations have finished.
+
+template <typename Job, typename... Continuations>
+typename std::enable_if<
+    boost::mpl::and_<boost::asynchronous::detail::has_is_continuation_task<Continuations>...>::type::value,
+    boost::asynchronous::detail::callback_continuation<
+        boost::asynchronous::any_of_result<typename Continuations::return_type...>,
+        Job
+    >
+>::type
+any_of_job(Continuations... continuations)
+{
+    return boost::asynchronous::top_level_callback_continuation_job<boost::asynchronous::any_of_result<typename Continuations::return_type...>, Job>(
+        boost::asynchronous::detail::any_of_helper<Job, Continuations...>(std::move(continuations)...)
+    );
+}
+
+template <typename... Continuations>
+auto any_of(Continuations... continuations)
+    -> decltype(any_of_job<typename boost::asynchronous::detail::job_type_from<Continuations...>::type, Continuations...>(std::move(continuations)...))
+{
+    return any_of_job<typename boost::asynchronous::detail::job_type_from<Continuations...>::type, Continuations...>(std::move(continuations)...);
+}
+
+} // namespace asynchronous
+} // namespace boost
+
+#endif // BOOST_ASYNCHRONOUS_ANY_OF_CONT_HPP

--- a/boost/asynchronous/algorithm/any_of.hpp
+++ b/boost/asynchronous/algorithm/any_of.hpp
@@ -124,22 +124,6 @@ private:
     variant_type m_value;
 };
 
-// Exception storage. This is itself an exception, so we can throw this and retreive the underlying exceptions.
-struct any_of_exception : public boost::asynchronous::asynchronous_exception
-{
-    any_of_exception(size_t count)
-        : m_underlying(count)
-    {}
-
-    const char* what() const noexcept override { return "any_of_exception"; }
-
-    std::vector<std::exception_ptr>& underlying_exceptions() { return m_underlying; }
-    const std::vector<std::exception_ptr>& underlying_exceptions() const { return m_underlying; }
-
-private:
-    std::vector<std::exception_ptr> m_underlying;
-};
-
 namespace detail
 {
 
@@ -153,7 +137,7 @@ struct any_of_task_counter
     {}
 
     Storage storage;
-    any_of_exception exceptions;
+    boost::asynchronous::combined_exception exceptions;
     std::atomic<size_t> failures_remaining;
     std::atomic_flag has_value;
 

--- a/boost/asynchronous/algorithm/detail/helpers.hpp
+++ b/boost/asynchronous/algorithm/detail/helpers.hpp
@@ -30,6 +30,13 @@ struct range_value_type
 {
     using type = typename std::remove_reference<typename std::remove_cv<decltype(*boost::begin(std::declval<Range>()))>::type>::type;
 };
+
+// Wrapper to avoid void and void&& arguments and tuple elements
+struct void_wrapper {};
+
+template <class T> struct wrap { using type = T; };
+template <> struct wrap<void> { using type = void_wrapper; };
+
 }
 }}
 #endif // BOOST_ASYNCHRONOUS_ALGORITHMS_DETAIL_HELPERS_HPP

--- a/boost/asynchronous/algorithm/parallel_kmp.hpp
+++ b/boost/asynchronous/algorithm/parallel_kmp.hpp
@@ -1,0 +1,434 @@
+// Boost.Asynchronous library
+//  Copyright (C) Tobias Holl 2018
+//
+//  Use, modification and distribution is subject to the Boost
+//  Software License, Version 1.0.  (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// For more information, see http://www.boost.org
+
+#ifndef BOOST_ASYNCHRONOUS_PARALLEL_KMP_HPP
+#define BOOST_ASYNCHRONOUS_PARALLEL_KMP_HPP
+
+#include <functional>
+#include <iterator>
+#include <memory>
+#include <type_traits>
+
+#include <boost/asynchronous/algorithm/detail/safe_advance.hpp>
+#include <boost/asynchronous/algorithm/then.hpp>
+#include <boost/asynchronous/continuation_task.hpp>
+#include <boost/asynchronous/detail/job_type_from.hpp>
+
+
+namespace boost
+{
+namespace asynchronous
+{
+
+// This is a parallel implementation of the Knuth-Morris-Pratt search algorithm.
+// It is mostly intended for substring search, but works for any type of iterable range.
+// N.B. that this implementation (unlike most other parallel implementations of KMP)
+// parallelizes over the length of the "haystack" string, not the number of searched
+// "needles" (which is trivially done using other algorithms like parallel_for).
+
+namespace detail
+{
+
+// The failure function of KMP describes how many characters of the haystack string we
+// can skip when a mismatch occurs. This allows a more efficient search of the haystack,
+// in O(n + m) instead of O(nm) time.
+using kmp_failure_function = std::vector<ssize_t>;
+
+// This function builds the "failure function"
+template <typename Iterator>
+kmp_failure_function build_kmp_failure_function(Iterator begin, Iterator end)
+{
+    auto items = std::distance(begin, end);
+    kmp_failure_function T(items + 1);
+
+    T[0] = -1;
+    ssize_t candidate = 0;
+    for (decltype(items) index = 1; index < items; ++index, ++candidate)
+    {
+        if (*(begin + index) == *(begin + candidate))
+        {
+            T[index] = T[candidate];
+        }
+        else
+        {
+            T[index] = candidate;
+            do { candidate = T[candidate]; }
+            while (candidate >= 0 && *(begin + index) != *(begin + candidate));
+        }
+    }
+    T[items] = candidate;
+
+    return T;
+}
+
+// The actual implementation of KMP.
+template <typename NeedleIterator>
+struct kmp_matcher
+{
+    kmp_matcher(NeedleIterator begin, NeedleIterator end)
+        : needle_begin(begin)
+        , needle_end(end)
+        , needle_size(static_cast<ssize_t>(std::distance(begin, end)))
+        , failure_function(boost::asynchronous::detail::build_kmp_failure_function(begin, end))
+    {}
+
+    template <typename HaystackIterator, typename HaystackIndex, typename Functor>
+    void operator()(HaystackIterator begin, HaystackIterator end, HaystackIndex begin_index, Functor& functor) const
+    {
+        HaystackIndex haystack_offset = 0;
+        HaystackIndex haystack_chunk_size = std::distance(begin, end);
+        ssize_t needle_offset = 0;
+        while (haystack_offset != haystack_chunk_size)
+        {
+            if (*(begin + haystack_offset) == *(needle_begin + needle_offset))
+            {
+                // Matched, advance both positions
+                ++needle_offset;
+                ++haystack_offset;
+                // Check if we have matched all characters
+                if (needle_offset == needle_size)
+                {
+                    functor(begin_index + haystack_offset - needle_size);
+                    needle_offset = failure_function[needle_offset];
+                }
+            }
+            else
+            {
+                // We failed, shift by the failure function
+                needle_offset = failure_function[needle_offset];
+                // If the failure function gives -1, advance the position in the haystack
+                if (needle_offset < 0)
+                {
+                    ++needle_offset;
+                    ++haystack_offset;
+                }
+            }
+        }
+    }
+
+    NeedleIterator needle_begin;
+    NeedleIterator needle_end;
+    ssize_t        needle_size;
+    kmp_failure_function failure_function;
+};
+
+template <typename Iterator, typename KmpMatcher, typename Functor, typename IndexType, typename Job>
+struct parallel_kmp_helper : public boost::asynchronous::continuation_task<Functor>
+{
+    parallel_kmp_helper(Iterator first, Iterator last, KmpMatcher matcher, Functor functor, IndexType offset, long cutoff, const std::string& task_name, std::size_t prio)
+        : boost::asynchronous::continuation_task<Functor>(task_name)
+        , first_(first)
+        , last_(last)
+        , matcher_(std::move(matcher))
+        , functor_(std::move(functor))
+        , offset_(offset)
+        , cutoff_(cutoff)
+        , prio_(prio)
+    {}
+
+    void operator()()
+    {
+        boost::asynchronous::continuation_result<Functor> task_res = this->this_task_result();
+        try
+        {
+            // Advance first_, depending on the iterator type (either by the specified cutoff exactly, or to the half-way mark)
+            Iterator middle = boost::asynchronous::detail::find_cutoff(first_, cutoff_, last_);
+
+            // Advance middle by the length of the needle that we are searching for
+            Iterator padded = middle;
+            boost::asynchronous::detail::safe_advance(padded, matcher_.needle_size - 1, last_);
+
+            // If we can't split further, run the KMP matcher. Otherwise, recurse.
+            if (padded == last_)
+            {
+                matcher_(first_, padded, offset_, functor_);
+                task_res.set_value(std::move(functor_));
+            }
+            else
+            {
+                // Compute the offset of the middle element
+                IndexType middle_offset = offset_ + std::distance(first_, middle);
+
+                // Recurse.
+                boost::asynchronous::create_callback_continuation_job<Job>(
+                    [task_res](std::tuple<boost::asynchronous::expected<Functor>, boost::asynchronous::expected<Functor>> result) mutable
+                    {
+                        try
+                        {
+                            // Check for exceptions
+                            auto functor = std::get<0>(result).get();
+                            functor.merge(std::move(std::get<1>(result).get()));
+                            task_res.set_value(std::move(functor));
+                        }
+                        catch (...)
+                        {
+                            task_res.set_exception(std::current_exception());
+                        }
+                    },
+                    parallel_kmp_helper<Iterator, KmpMatcher, Functor, IndexType, Job>(first_, padded, matcher_, functor_, offset_,       cutoff_, this->get_name(), prio_),
+                    parallel_kmp_helper<Iterator, KmpMatcher, Functor, IndexType, Job>(middle, last_,  matcher_, functor_, middle_offset, cutoff_, this->get_name(), prio_)
+                );
+            }
+        }
+        catch (...)
+        {
+            task_res.set_exception(std::current_exception());
+        }
+    }
+
+    Iterator    first_;
+    Iterator    last_;
+    KmpMatcher  matcher_;
+    Functor     functor_;
+    IndexType   offset_;
+    long        cutoff_;
+    std::size_t prio_;
+};
+
+// Pure iterator version (this is the base implementation that all other combinations of argument types rely on)
+template <typename Job, typename HaystackIterator, typename NeedleIterator, typename Functor>
+boost::asynchronous::detail::callback_continuation<Functor, Job>
+parallel_kmp_impl(
+    HaystackIterator first, HaystackIterator last,
+    NeedleIterator s_first, NeedleIterator s_last,
+    Functor functor, long cutoff,
+    const std::string& task_name, std::size_t prio
+)
+{
+    boost::asynchronous::detail::kmp_matcher<NeedleIterator> matcher(s_first, s_last);
+    return boost::asynchronous::top_level_callback_continuation_job<Functor, Job>(
+        boost::asynchronous::detail::parallel_kmp_helper<HaystackIterator, decltype(matcher), Functor, decltype(std::distance(first, last)), Job>(
+            first, last, std::move(matcher), std::move(functor), 0, cutoff, task_name, prio
+        )
+    );
+}
+
+// Check if a functor type is a valid functor for parallel_kmp
+template <typename F>
+struct is_kmp_functor
+{
+private:
+    // Check for the function call operator (operator()(const index_type&))
+    template <typename T> static auto has_call_operator(T* t) -> decltype((*t)(0), void(), std::true_type{});
+    template <typename T> static auto has_call_operator(...)  -> decltype(std::false_type{});
+    // Check for the merge operation (merge(const functor_type&) or merge(functor_type&&))
+    template <typename T> static auto has_merge(T* a, T* b) -> decltype(a->merge(std::move(*b)), void(), std::true_type{});
+    template <typename T> static auto has_merge(...)        -> decltype(std::false_type{});
+
+public:
+    constexpr static bool value = decltype(has_call_operator<F>(nullptr))::value && decltype(has_merge<F>(nullptr, nullptr))::value;
+};
+
+} // detail
+
+// Preprocessor magic to generate all 16 different combinations.
+
+// BOOST_ASYNC_KMP_IMPL_CHECK_...: Checks the conditions on the specific argument type
+#define BOOST_ASYNC_KMP_IMPL_CHECK_ITER(argtype) true
+#define BOOST_ASYNC_KMP_IMPL_CHECK_RNGE(argtype) !boost::asynchronous::detail::has_is_continuation_task<typename std::decay<argtype>::type>::value
+#define BOOST_ASYNC_KMP_IMPL_CHECK_MOVE(argtype) !boost::asynchronous::detail::has_is_continuation_task<typename std::decay<argtype>::type>::value
+#define BOOST_ASYNC_KMP_IMPL_CHECK_CONT(argtype) boost::asynchronous::detail::has_is_continuation_task<typename std::decay<argtype>::type>::value
+
+// BOOST_ASYNC_KMP_IMPL_ARGS_...: Unwraps the prefix and type into function argument code
+#define BOOST_ASYNC_KMP_IMPL_ARGS_ITER(prefix, argtype) argtype prefix##begin, argtype prefix##end
+#define BOOST_ASYNC_KMP_IMPL_ARGS_RNGE(prefix, argtype) const argtype& prefix##range
+#define BOOST_ASYNC_KMP_IMPL_ARGS_MOVE(prefix, argtype) argtype&& prefix##range
+#define BOOST_ASYNC_KMP_IMPL_ARGS_CONT(prefix, argtype) argtype prefix##continuation
+
+// BOOST_ASYNC_KMP_IMPL_OTHER_ARGS: The remaining arguments that are always the same
+#ifdef BOOST_ASYNCHRONOUS_REQUIRE_ALL_ARGUMENTS
+#define BOOST_ASYNC_KMP_IMPL_OTHER_ARGS Functor functor, long cutoff, const std::string& task_name, std::size_t prio
+#else
+#define BOOST_ASYNC_KMP_IMPL_OTHER_ARGS Functor functor, long cutoff, const std::string& task_name = "", std::size_t prio = 0
+#endif
+
+// BOOST_ASYNC_KMP_IMPL_UNWRAP_...: Adapts the function to the specified argument modes
+// The iterator version does not need to do anything (we want iterators for the baseline implementation)
+// The range (reference) version just uses begin and end to get the iterators we need
+// If the range is moved, we keep it alive while the inner code runs
+// For continuations, we need to use boost::asynchronous::then on the input
+// The _INIT variants are run at the start of the function.
+#define BOOST_ASYNC_KMP_IMPL_UNWRAP_INIT_ITER(prefix)
+#define BOOST_ASYNC_KMP_IMPL_UNWRAP_INIT_RNGE(prefix) \
+    using std::begin;                                 \
+    using std::end;                                   \
+    auto prefix##begin = begin(prefix##range);        \
+    auto prefix##end   = end(prefix##range);
+#define BOOST_ASYNC_KMP_IMPL_UNWRAP_INIT_MOVE(prefix)                               \
+    using prefix##type = typename std::decay<decltype(prefix##range)>::type;        \
+    auto prefix##shared = std::make_shared<prefix##type>(std::move(prefix##range)); \
+    using std::begin;                                                               \
+    using std::end;                                                                 \
+    auto prefix##begin = begin(*prefix##shared);                                    \
+    auto prefix##end   = end(*prefix##shared);
+#define BOOST_ASYNC_KMP_IMPL_UNWRAP_INIT_CONT(prefix) \
+    using prefix##result = typename std::decay<decltype(prefix##continuation)>::type::return_type;
+
+#define BOOST_ASYNC_KMP_IMPL_UNWRAP_ITER(prefix, args, next) next
+#define BOOST_ASYNC_KMP_IMPL_UNWRAP_RNGE(prefix, args, next) next
+#define BOOST_ASYNC_KMP_IMPL_UNWRAP_MOVE(prefix, args, next)                                          \
+    boost::asynchronous::then_job<Job>(                                                               \
+        next,                                                                                         \
+        [prefix##shared](boost::asynchronous::expected<Functor> expected) { return expected.get(); }, \
+        task_name + ": boost::asynchronous::parallel_kmp: keep-alive of moved range"                  \
+    )
+#define BOOST_ASYNC_KMP_IMPL_UNWRAP_CONT(prefix, args, next)                                                  \
+    boost::asynchronous::then_job<Job>(                                                                       \
+        std::move(prefix##continuation),                                                                      \
+        [args](boost::asynchronous::expected<prefix##result> expected) mutable                                \
+        {                                                                                                     \
+            auto prefix##shared = std::make_shared<prefix##result>(std::move(expected.get()));                \
+            using std::begin;                                                                                 \
+            using std::end;                                                                                   \
+            auto prefix##begin = begin(*prefix##shared);                                                      \
+            auto prefix##end   = end(*prefix##shared);                                                        \
+            return boost::asynchronous::then_job<Job>(                                                        \
+                next,                                                                                         \
+                [prefix##shared](boost::asynchronous::expected<Functor> expected) { return expected.get(); }, \
+                task_name + ": boost::asynchronous::parallel_kmp: keep-alive of moved range"                  \
+            );                                                                                                \
+        },                                                                                                    \
+        task_name + ": boost::asynchronous::parallel_kmp: argument callback"                                  \
+    )
+
+// BOOST_ASYNC_KMP_IMPL_CAPTURE_...: Things we need to capture until the callback from a continuation argument comes, and how we capture them.
+// Because these happen after BOOST_ASYNC_KMP_IMPL_UNWRAP_INIT_..., we capture iterators for all but the continuation versions.
+// Because we do not want to keep the continuation around on which we call boost::asynchronous::then, there are three versions of this:
+// BEFORE is used when the capture happens before the relevant UNWRAP (captures continuations etc.), WHILE is used during the relevant UNWRAP
+// (does not capture continuations nor the resulting iterators), and AFTER is used after the UNWRAP (captures iterators resulting from
+// continuation arguments).
+#define BOOST_ASYNC_KMP_IMPL_CAPTURE_BEFORE_ITER(prefix) prefix##begin, prefix##end,
+#define BOOST_ASYNC_KMP_IMPL_CAPTURE_BEFORE_RNGE(prefix) prefix##begin, prefix##end,
+#define BOOST_ASYNC_KMP_IMPL_CAPTURE_BEFORE_MOVE(prefix) prefix##begin, prefix##end, prefix##shared,
+#define BOOST_ASYNC_KMP_IMPL_CAPTURE_BEFORE_CONT(prefix) prefix##continuation,
+#define BOOST_ASYNC_KMP_IMPL_CAPTURE_WHILE_ITER(prefix) prefix##begin, prefix##end,
+#define BOOST_ASYNC_KMP_IMPL_CAPTURE_WHILE_RNGE(prefix) prefix##begin, prefix##end,
+#define BOOST_ASYNC_KMP_IMPL_CAPTURE_WHILE_MOVE(prefix) prefix##begin, prefix##end, prefix##shared,
+#define BOOST_ASYNC_KMP_IMPL_CAPTURE_WHILE_CONT(prefix)
+#define BOOST_ASYNC_KMP_IMPL_CAPTURE_AFTER_ITER(prefix) prefix##begin, prefix##end,
+#define BOOST_ASYNC_KMP_IMPL_CAPTURE_AFTER_RNGE(prefix) prefix##begin, prefix##end,
+#define BOOST_ASYNC_KMP_IMPL_CAPTURE_AFTER_MOVE(prefix) prefix##begin, prefix##end, prefix##shared,
+#define BOOST_ASYNC_KMP_IMPL_CAPTURE_AFTER_CONT(prefix) prefix##begin, prefix##end, prefix##shared,
+
+// BOOST_ASYNC_KMP_IMPL_OTHER_CAPTURES: The remaining captures, independent of mode
+#ifdef __cpp_init_captures
+#define BOOST_ASYNC_KMP_IMPL_OTHER_CAPTURES functor = std::move(functor), cutoff, task_name, prio
+#else
+#define BOOST_ASYNC_KMP_IMPL_OTHER_CAPTURES functor, cutoff, task_name, prio
+#endif
+
+// BOOST_ASYNC_KMP_IMPL_CAPTURES: Lists all the captures
+#define BOOST_ASYNC_KMP_IMPL_CAPTURES(h_modif, h_capture_mode, n_modif, n_capture_mode) \
+    BOOST_ASYNC_KMP_IMPL_CAPTURE_##h_capture_mode##_##h_modif(h_)                       \
+    BOOST_ASYNC_KMP_IMPL_CAPTURE_##n_capture_mode##_##n_modif(n_)                       \
+    BOOST_ASYNC_KMP_IMPL_OTHER_CAPTURES
+
+// BOOST_ASYNC_KMP_IMPL_DELEGATE: The function we ultimately want to call
+#define BOOST_ASYNC_KMP_IMPL_DELEGATE boost::asynchronous::detail::parallel_kmp_impl<Job>(h_begin, h_end, n_begin, n_end, std::move(functor), cutoff, task_name, prio)
+
+// BOOST_ASYNC_KMP_IMPL: Build a parallel_kmp function for the specified argument modes
+#define BOOST_ASYNC_KMP_IMPL(h_modif, n_modif)                                                                                                                         \
+    template <                                                                                                                                                         \
+        typename Haystack,                                                                                                                                             \
+        typename Needle,                                                                                                                                               \
+        typename Functor,                                                                                                                                              \
+        typename Job = typename boost::asynchronous::detail::job_type_from<Haystack, Needle>::type                                                                     \
+    >                                                                                                                                                                  \
+    typename std::enable_if<                                                                                                                                           \
+        boost::asynchronous::detail::is_kmp_functor<Functor>::value && BOOST_ASYNC_KMP_IMPL_CHECK_##h_modif(Haystack) && BOOST_ASYNC_KMP_IMPL_CHECK_##n_modif(Needle), \
+        boost::asynchronous::detail::callback_continuation<Functor, Job>                                                                                               \
+    >::type                                                                                                                                                            \
+    parallel_kmp(                                                                                                                                                      \
+        BOOST_ASYNC_KMP_IMPL_ARGS_##h_modif(h_, Haystack),                                                                                                             \
+        BOOST_ASYNC_KMP_IMPL_ARGS_##n_modif(n_, Needle),                                                                                                               \
+        BOOST_ASYNC_KMP_IMPL_OTHER_ARGS                                                                                                                                \
+    )                                                                                                                                                                  \
+    {                                                                                                                                                                  \
+        BOOST_ASYNC_KMP_IMPL_UNWRAP_INIT_##h_modif(h_)                                                                                                                 \
+        BOOST_ASYNC_KMP_IMPL_UNWRAP_INIT_##n_modif(n_)                                                                                                                 \
+        return BOOST_ASYNC_KMP_IMPL_UNWRAP_##h_modif(                                                                                                                  \
+            h_,                                                                                                                                                        \
+            BOOST_ASYNC_KMP_IMPL_CAPTURES(h_modif, WHILE, n_modif, BEFORE),                                                                                            \
+            BOOST_ASYNC_KMP_IMPL_UNWRAP_##n_modif(                                                                                                                     \
+                n_,                                                                                                                                                    \
+                BOOST_ASYNC_KMP_IMPL_CAPTURES(h_modif, AFTER, n_modif, WHILE),                                                                                         \
+                BOOST_ASYNC_KMP_IMPL_DELEGATE                                                                                                                          \
+            )                                                                                                                                                          \
+        );                                                                                                                                                             \
+    }
+
+// These versions allow taking any combination of iterators, ranges (by reference or moved), and continuations.
+// Always called as parallel_kmp(haystack, needle, functor, ...), but 'haystack' and 'needle' can also be two iterators
+// instead of a single argument.
+// The functor acts like the functor for parallel_for_each, it should implement 'void operator()(const index_type&)'
+// (where index_type is an integral type usable for indexing into the haystack), and 'void merge(const functor_type&)'
+// or 'void merge(functor_type&&)', which is called on the first of the two functors when two chunks of work are finished.
+// The continuation returns the functor type that was passed in.
+
+BOOST_ASYNC_KMP_IMPL(ITER, ITER)
+BOOST_ASYNC_KMP_IMPL(ITER, RNGE)
+BOOST_ASYNC_KMP_IMPL(ITER, MOVE)
+BOOST_ASYNC_KMP_IMPL(ITER, CONT)
+
+BOOST_ASYNC_KMP_IMPL(RNGE, ITER)
+BOOST_ASYNC_KMP_IMPL(RNGE, RNGE)
+BOOST_ASYNC_KMP_IMPL(RNGE, MOVE)
+BOOST_ASYNC_KMP_IMPL(RNGE, CONT)
+
+BOOST_ASYNC_KMP_IMPL(MOVE, ITER)
+BOOST_ASYNC_KMP_IMPL(MOVE, RNGE)
+BOOST_ASYNC_KMP_IMPL(MOVE, MOVE)
+BOOST_ASYNC_KMP_IMPL(MOVE, CONT)
+
+BOOST_ASYNC_KMP_IMPL(CONT, ITER)
+BOOST_ASYNC_KMP_IMPL(CONT, RNGE)
+BOOST_ASYNC_KMP_IMPL(CONT, MOVE)
+BOOST_ASYNC_KMP_IMPL(CONT, CONT)
+
+// Undefine anything that might cause trouble
+#undef BOOST_ASYNC_KMP_IMPL
+#undef BOOST_ASYNC_KMP_IMPL_DELEGATE
+#undef BOOST_ASYNC_KMP_IMPL_CAPTURES
+#undef BOOST_ASYNC_KMP_IMPL_OTHER_CAPTURES
+#undef BOOST_ASYNC_KMP_IMPL_OTHER_CAPTURES
+#undef BOOST_ASYNC_KMP_IMPL_CAPTURE_AFTER_CONT
+#undef BOOST_ASYNC_KMP_IMPL_CAPTURE_AFTER_MOVE
+#undef BOOST_ASYNC_KMP_IMPL_CAPTURE_AFTER_RNGE
+#undef BOOST_ASYNC_KMP_IMPL_CAPTURE_AFTER_ITER
+#undef BOOST_ASYNC_KMP_IMPL_CAPTURE_WHILE_CONT
+#undef BOOST_ASYNC_KMP_IMPL_CAPTURE_WHILE_MOVE
+#undef BOOST_ASYNC_KMP_IMPL_CAPTURE_WHILE_RNGE
+#undef BOOST_ASYNC_KMP_IMPL_CAPTURE_WHILE_ITER
+#undef BOOST_ASYNC_KMP_IMPL_CAPTURE_BEFORE_CONT
+#undef BOOST_ASYNC_KMP_IMPL_CAPTURE_BEFORE_MOVE
+#undef BOOST_ASYNC_KMP_IMPL_CAPTURE_BEFORE_RNGE
+#undef BOOST_ASYNC_KMP_IMPL_CAPTURE_BEFORE_ITER
+#undef BOOST_ASYNC_KMP_IMPL_UNWRAP_CONT
+#undef BOOST_ASYNC_KMP_IMPL_UNWRAP_MOVE
+#undef BOOST_ASYNC_KMP_IMPL_UNWRAP_RNGE
+#undef BOOST_ASYNC_KMP_IMPL_UNWRAP_ITER
+#undef BOOST_ASYNC_KMP_IMPL_UNWRAP_INIT_CONT
+#undef BOOST_ASYNC_KMP_IMPL_UNWRAP_INIT_MOVE
+#undef BOOST_ASYNC_KMP_IMPL_UNWRAP_INIT_RNGE
+#undef BOOST_ASYNC_KMP_IMPL_UNWRAP_INIT_ITER
+#undef BOOST_ASYNC_KMP_IMPL_OTHER_ARGS
+#undef BOOST_ASYNC_KMP_IMPL_OTHER_ARGS
+#undef BOOST_ASYNC_KMP_IMPL_ARGS_CONT
+#undef BOOST_ASYNC_KMP_IMPL_ARGS_MOVE
+#undef BOOST_ASYNC_KMP_IMPL_ARGS_RNGE
+#undef BOOST_ASYNC_KMP_IMPL_ARGS_ITER
+#undef BOOST_ASYNC_KMP_IMPL_CHECK_CONT
+#undef BOOST_ASYNC_KMP_IMPL_CHECK_MOVE
+#undef BOOST_ASYNC_KMP_IMPL_CHECK_RNGE
+#undef BOOST_ASYNC_KMP_IMPL_CHECK_ITER
+
+} // namespace asynchronous
+} // namespace boost
+
+#endif // BOOST_ASYNCHRONOUS_PARALLEL_KMP_HPP

--- a/boost/asynchronous/algorithm/then.hpp
+++ b/boost/asynchronous/algorithm/then.hpp
@@ -14,6 +14,7 @@
 #include <functional>
 #include <type_traits>
 
+#include <boost/asynchronous/algorithm/detail/helpers.hpp>
 #include <boost/asynchronous/detail/continuation_impl.hpp>
 #include <boost/asynchronous/detail/metafunctions.hpp>
 #include <boost/asynchronous/continuation_task.hpp>
@@ -24,12 +25,6 @@ namespace asynchronous
 {
 namespace detail
 {
-
-// Wrapper to avoid void and void&& argument types
-struct void_wrapper {};
-
-template <class T> struct wrap { using type = T; };
-template <> struct wrap<void> { using type = void_wrapper; };
 
 // The result of applying the functor to the given continuation
 template <class Continuation, class Functor>

--- a/boost/asynchronous/detail/job_type_from.hpp
+++ b/boost/asynchronous/detail/job_type_from.hpp
@@ -1,0 +1,38 @@
+#ifndef BOOST_ASYNCHRONOUS_JOB_TYPE_FROM_HPP
+#define BOOST_ASYNCHRONOUS_JOB_TYPE_FROM_HPP
+
+#include <boost/asynchronous/callable_any.hpp>
+
+namespace boost
+{
+namespace asynchronous
+{
+namespace detail
+{
+
+// Attempts to deduce the job type from a list of types that might be continuations (it stops at the first).
+// If no continuation is found, we use BOOST_ASYNCHRONOUS_DEFAULT_JOB.
+
+// The unspecialized version does nothing, because we specialize for both continuation and non-continuation.
+template <typename... Ts> struct job_type_from;
+
+// If no continuations are left, use the default job type.
+template <> struct job_type_from<> { using type = BOOST_ASYNCHRONOUS_DEFAULT_JOB; };
+
+// Otherwise, check if the first type is a continuation.
+template <typename T, typename... Ts>
+struct job_type_from<T, Ts...>
+{
+private:
+    template <typename U, typename Job = typename U::job_type> static Job job_detector(const U&); // Returns the job type of U. Version is SFINAE'd away if U is not a continuation
+    static typename job_type_from<Ts...>::type                            job_detector(...);      // Returns the deduced return type of the remaining types.
+
+public:
+    using type = decltype(job_detector(std::declval<T>())); // Will try to match the continuation version, but fall back to the recursive detection if T is not a continuation.
+};
+
+} // namespace detail
+} // namespace asynchronous
+} // namespace boost
+
+#endif // BOOST_ASYNCHRONOUS_JOB_TYPE_FROM_HPP

--- a/boost/asynchronous/exceptions.hpp
+++ b/boost/asynchronous/exceptions.hpp
@@ -83,5 +83,22 @@ struct task_aborted_exception : public boost::asynchronous::asynchronous_excepti
       return "task_aborted_exception";
     }
 };
+
+// Exception consisting of multiple underlying exceptions.
+struct combined_exception : public boost::asynchronous::asynchronous_exception
+{
+    combined_exception(size_t count)
+        : m_underlying(count)
+    {}
+
+    const char* what() const noexcept override { return "any_of_exception"; }
+
+    std::vector<std::exception_ptr>& underlying_exceptions() { return m_underlying; }
+    const std::vector<std::exception_ptr>& underlying_exceptions() const { return m_underlying; }
+
+private:
+    std::vector<std::exception_ptr> m_underlying;
+};
+
 }}
 #endif // BOOST_ASYNCHRON_EXCEPTIONS_HPP

--- a/libs/asynchronous/doc/asynchronous.xml
+++ b/libs/asynchronous/doc/asynchronous.xml
@@ -2997,6 +2997,12 @@ auto scheduler = boost::asynchronous::create_shared_scheduler_proxy(
                                     <entry>Iterators, moved range, continuation</entry>
                                     <entry>No</entry>
                                 </row>
+                                <row>
+                                    <entry><command xlink:href="#parallel_kmp">parallel_kmp</command></entr>
+                                    <entry>searches a range of elements for a subsequence using the Knuth-Morris-Pratt algorithm</entry>
+                                    <entry>parallel_kmp.hpp</entry>
+                                    <entry>Iterators, moved ranges, continuations</entry>
+                                    <entry>No</entry>
                             </tbody>
                         </tgroup>
                     </table></para><para></para>
@@ -4483,6 +4489,47 @@ boost::asynchronous::detail::callback_continuation&lt;<emphasis role="bold">Unsp
                                 continuation</para>
                         </listitem>
                     </itemizedlist></para>
+                </sect2>
+                <sect2>
+                    <title><command xml:id="parallel_kmp"/>parallel_kmp</title>
+                    <para>Searches a range of elements (such as a string) for a subsequence. On each match, a functor is called with the index of the matched subsequence. This functor can save data and is merged with other instances of this functor (like parallel_for_each). This allows the caller to either obtain a list of all matches (by keeping track of the matched indices when merging) or just performing an operation directly when the match is found. The algorithm returns the last merged instance of the functor type.</para>
+                    <programlisting>template &lt;/* see below */, class Functor, class Job=/* see below */&gt;
+boost::asynchronous::detail::callback_continuation&lt;<emphasis role="bold">Functor</emphasis>,Job>
+<emphasis role="bold">parallel_kmp</emphasis>(/* see below */, Functor functor, long cutoff, const std::string&amp; task_name="", std::size_t prio=0);</programlisting>
+                    <para>Both the range of elements that will be searched ("haystack") and the subsequence that is searched for ("needle") can be passed to parallel_kmp as either a pair of iterators (begin and end), as a range (taken by reference or moved into parallel_kmp), or as a continuation that returns the range in question</para>
+                    <para><emphasis role="underline">Return value</emphasis>: A merged instance of a
+                        functor of type Func.</para>
+                    <para><emphasis role="underline">Parameters</emphasis>: <itemizedlist>
+                        <listitem>
+                            <para>The "haystack": the range of elements to search in (as iterators, as a range, or as a continuation)</para>
+                        </listitem>
+                        <listitem>
+                            <para>The "needle": the range of elements to search for (as iterators, as a range, or as a continuation)</para>
+                        </listitem>
+                        <listitem>
+                            <para>functor: an object with:</para>
+                                <para>
+                                    <itemizedlist>
+                                        <listitem>
+                                            <para>void operator()(const index_type&amp;), where index_type is the type used to index into the haystack range</para>
+                                        </listitem>
+                                        <listitem>
+                                            <para>void merge(const Functor&amp;) or void merge(Functor&amp;&amp;) (the latter is preferred if it is available)</para>
+                                        </listitem>
+                                    </itemizedlist>
+                                </para>
+                        </listitem>
+                        <listitem>
+                            <para>cutoff: the maximum size of a sequential chunk</para>
+                        </listitem>
+                        <listitem>
+                            <para>task_name: the name displayed in the scheduler diagnostics</para>
+                        </listitem>
+                        <listitem>
+                            <para>prio: task priority </para>
+                        </listitem>
+                    </itemizedlist></para>
+                    <para>When passing iterators or a reference to a range to this algorithm, the programmer must ensure that the reference or iterators stay valid until the algorithm completes.</para>
                 </sect2>
                 <sect2>
                     <title><command xml:id="parallel_copy"/>parallel_copy</title>

--- a/libs/asynchronous/test/test_continuation_any_all.cpp
+++ b/libs/asynchronous/test/test_continuation_any_all.cpp
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(test_continuation_any_of_only_exceptions)
         static_assert(std::is_same<typename std::decay<decltype(result)>::type, boost::asynchronous::any_of_result<std::vector<int>, std::vector<int>, std::vector<int>>>::value, "Incorrect return type for any_of");
         BOOST_FAIL("Should have gotten an exception");
     }
-    catch (const boost::asynchronous::any_of_exception& e)
+    catch (const boost::asynchronous::combined_exception& e)
     {
         std::vector<std::string> messages = {"Testing exception propagation from 'a'", "Testing exception propagation from 'b'", "Testing exception propagation from 'c'"};
 

--- a/libs/asynchronous/test/test_continuation_any_all.cpp
+++ b/libs/asynchronous/test/test_continuation_any_all.cpp
@@ -1,0 +1,190 @@
+// Boost.Asynchronous library
+//  Copyright (C) Tobias Holl 2018
+//
+//  Use, modification and distribution is subject to the Boost
+//  Software License, Version 1.0.  (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// For more information, see http://www.boost.org
+
+#include <vector>
+#include <random>
+#include <future>
+
+#include <boost/asynchronous/queue/lockfree_queue.hpp>
+#include <boost/asynchronous/scheduler_shared_proxy.hpp>
+#include <boost/asynchronous/scheduler/threadpool_scheduler.hpp>
+
+#include <boost/asynchronous/post.hpp>
+#include <boost/asynchronous/algorithm/all_of.hpp>
+#include <boost/asynchronous/algorithm/any_of.hpp>
+#include <boost/asynchronous/algorithm/parallel_for.hpp>
+#include <boost/asynchronous/algorithm/parallel_reduce.hpp>
+#include <boost/asynchronous/algorithm/parallel_sort.hpp>
+
+#include "test_common.hpp"
+
+#include <boost/test/unit_test.hpp>
+using namespace boost::asynchronous::test;
+
+namespace
+{
+
+std::vector<int> generate(size_t size = 10000)
+{
+    std::vector<int> data(size);
+    std::random_device rd;
+    std::mt19937 mt(rd());
+    std::generate(data.begin(), data.end(), mt);
+    return data;
+}
+
+BOOST_AUTO_TEST_CASE(test_continuation_all_of)
+{
+    auto scheduler = boost::asynchronous::make_shared_scheduler_proxy<boost::asynchronous::threadpool_scheduler<boost::asynchronous::lockfree_queue<>>>(6);
+
+    auto a = generate();
+    auto b = generate();
+    auto c = std::vector<int>(10000, 42);
+
+    auto fu = boost::asynchronous::post_future(
+        scheduler,
+        [&a, &b, &c]() mutable
+        {
+            return boost::asynchronous::all_of(
+                boost::asynchronous::parallel_sort(a.begin(), a.end(), std::less<int>(), 1500, "sort a", 0),
+                boost::asynchronous::parallel_sort(b.begin(), b.end(), std::less<int>(), 1500, "sort b", 0),
+                boost::asynchronous::parallel_reduce(c.begin(), c.end(), std::plus<int>(), 1500, "reduce c", 0)
+            );
+        },
+        "test_continuation_all_of",
+        0
+    );
+
+    try
+    {
+        auto tup = fu.get();
+        BOOST_CHECK_MESSAGE(std::is_sorted(a.begin(), a.end()), "Vector 'a'  was not sorted");
+        BOOST_CHECK_MESSAGE(std::is_sorted(b.begin(), b.end()), "Vector 'b'  was not sorted");
+        BOOST_CHECK_MESSAGE(std::get<2>(tup) == 420000, "parallel_reduce of vector 'c' returned the wrong result (" + std::to_string(std::get<2>(tup)) + ", should have been 420000)");
+        static_assert(std::is_same<typename std::decay<decltype(std::get<0>(tup))>::type, boost::asynchronous::detail::void_wrapper>::value, "parallel_sort of 'a' returned wrong type through all(...)");
+        static_assert(std::is_same<typename std::decay<decltype(std::get<1>(tup))>::type, boost::asynchronous::detail::void_wrapper>::value, "parallel_sort of 'b' returned wrong type through all(...)");
+        static_assert(std::is_same<typename std::decay<decltype(std::get<2>(tup))>::type, int>::value, "parallel_reduce of 'c' returned wrong type through all(...)");
+    }
+    catch (...)
+    {
+        BOOST_FAIL("Unexpected exception");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_continuation_all_of_with_exception)
+{
+    auto scheduler = boost::asynchronous::make_shared_scheduler_proxy<boost::asynchronous::threadpool_scheduler<boost::asynchronous::lockfree_queue<>>>(6);
+
+    auto a = generate();
+    auto b = generate();
+
+    auto fu = boost::asynchronous::post_future(
+        scheduler,
+        [&a, &b]() mutable
+        {
+            return boost::asynchronous::all_of(
+                boost::asynchronous::parallel_sort(a.begin(), a.end(), std::less<int>(), 1500, "sort a", 0),
+                boost::asynchronous::parallel_for(b.begin(), b.end(), [](const int&) { throw std::logic_error("Testing exception propagation"); }, 1500, "parallel_for of b", 0)
+            );
+        },
+        "test_continuation_all_of_with_exception",
+        0
+    );
+
+    try
+    {
+        fu.get();
+        BOOST_FAIL("Should have gotten an exception");
+    }
+    catch (const std::logic_error& e)
+    {
+        BOOST_CHECK_MESSAGE(e.what() == std::string("Testing exception propagation"), "Got incorrect exception message");
+    }
+    catch (...)
+    {
+        BOOST_FAIL("Unexpected exception");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_continuation_any_of)
+{
+    auto scheduler = boost::asynchronous::make_shared_scheduler_proxy<boost::asynchronous::threadpool_scheduler<boost::asynchronous::lockfree_queue<>>>(6);
+
+    auto a = std::make_shared<std::vector<int>>(10000000, 42);
+    auto b = std::make_shared<std::vector<int>>(  100000, 42);
+    auto c = std::make_shared<std::vector<int>>(     100, 42);
+    auto d = std::make_shared<std::vector<int>>(  100000, 42);
+
+    auto fu = boost::asynchronous::post_future(
+        scheduler,
+        [a, b, c, d]() mutable
+        {
+            return boost::asynchronous::any_of(
+                boost::asynchronous::parallel_reduce(std::move(*a), std::plus<int>(), 1500, "reduce a", 0),
+                boost::asynchronous::parallel_reduce(std::move(*b), std::plus<int>(), 1500, "reduce b", 0),
+                boost::asynchronous::parallel_reduce(std::move(*c), std::plus<int>(), 1500, "reduce c", 0),
+                boost::asynchronous::parallel_for(std::move(*d), [](const int&) { throw std::logic_error("Testing exception propagation"); }, 1500, "exception", 0)
+            );
+        },
+        "test_continuation_any_of",
+        0
+    );
+
+    try
+    {
+        auto result = fu.get();
+        static_assert(std::is_same<typename std::decay<decltype(result)>::type, boost::asynchronous::any_of_result<int, int, int, std::vector<int>>>::value, "Incorrect return type for any_of");
+        BOOST_CHECK_MESSAGE(result.index == 2, "Smallest continuation with result did not finish first");
+        BOOST_CHECK_MESSAGE(boost::get<int>(result.value) == 4200, "Smallest continuation returned the wrong result (" + std::to_string(boost::get<int>(result.value)) + ", should have been 4200)");
+    }
+    catch (...)
+    {
+        BOOST_FAIL("Unexpected exception");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_continuation_any_of_only_exceptions)
+{
+    auto scheduler = boost::asynchronous::make_shared_scheduler_proxy<boost::asynchronous::threadpool_scheduler<boost::asynchronous::lockfree_queue<>>>(6);
+
+    auto a = std::make_shared<std::vector<int>>(10000000, 42);
+    auto b = std::make_shared<std::vector<int>>(100000, 42);
+    auto c = std::make_shared<std::vector<int>>(100, 42);
+
+    auto fu = boost::asynchronous::post_future(
+        scheduler,
+        [a, b, c]() mutable
+        {
+            return boost::asynchronous::any_of(
+                boost::asynchronous::parallel_for(std::move(*a), [](const int&) { throw std::logic_error("Testing exception propagation"); }, 1500, "exception a", 0),
+                boost::asynchronous::parallel_for(std::move(*b), [](const int&) { throw std::logic_error("Testing exception propagation"); }, 1500, "exception b", 0),
+                boost::asynchronous::parallel_for(std::move(*c), [](const int&) { throw std::logic_error("Testing exception propagation"); }, 1500, "exception c", 0)
+            );
+        },
+        "test_continuation_any_of_only_exceptions",
+        0
+    );
+
+    try
+    {
+        auto result = fu.get();
+        static_assert(std::is_same<typename std::decay<decltype(result)>::type, boost::asynchronous::any_of_result<std::vector<int>, std::vector<int>, std::vector<int>>>::value, "Incorrect return type for any_of");
+        BOOST_FAIL("Should have gotten an exception");
+    }
+    catch (const std::logic_error& e)
+    {
+        BOOST_CHECK_MESSAGE(e.what() == std::string("Testing exception propagation"), "Got incorrect exception message");
+    }
+    catch (...)
+    {
+        BOOST_FAIL("Unexpected exception");
+    }
+}
+
+}

--- a/libs/asynchronous/test/test_parallel_kmp.cpp
+++ b/libs/asynchronous/test/test_parallel_kmp.cpp
@@ -1,0 +1,180 @@
+// Boost.Asynchronous library
+//  Copyright (C) Tobias Holl 2018
+//
+//  Use, modification and distribution is subject to the Boost
+//  Software License, Version 1.0.  (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// For more information, see http://www.boost.org
+
+#include <vector>
+#include <random>
+#include <future>
+
+#include <boost/asynchronous/queue/lockfree_queue.hpp>
+#include <boost/asynchronous/scheduler_shared_proxy.hpp>
+#include <boost/asynchronous/scheduler/threadpool_scheduler.hpp>
+
+#include <boost/asynchronous/post.hpp>
+#include <boost/asynchronous/algorithm/parallel_for.hpp>
+#include <boost/asynchronous/algorithm/parallel_kmp.hpp>
+
+#include "test_common.hpp"
+
+#include <boost/test/unit_test.hpp>
+using namespace boost::asynchronous::test;
+
+namespace
+{
+
+// We need some long non-copyrighted text to run KMP on in this example, so here are the first ten chapters of Caesar's Commentarii de Bello Gallico.
+std::string caesar = "Gallia est omnis divisa in partes tres, quarum unam incolunt Belgae, aliam Aquitani, tertiam qui ipsorum lingua Celtae, nostra Galli appellantur. Hi omnes lingua, institutis, "
+                     "legibus inter se differunt. Gallos ab Aquitanis Garumna flumen, a Belgis Matrona et Sequana dividit. Horum omnium fortissimi sunt Belgae, propterea quod a cultu atque humanitate "
+                     "provinciae longissime absunt, minimeque ad eos mercatores saepe commeant atque ea quae ad effeminandos animos pertinent important, proximique sunt Germanis, qui trans Rhenum "
+                     "incolunt, quibuscum continenter bellum gerunt. Qua de causa Helvetii quoque reliquos Gallos virtute praecedunt, quod fere cotidianis proeliis cum Germanis contendunt, cum aut "
+                     "suis finibus eos prohibent aut ipsi in eorum finibus bellum gerunt. Eorum una, pars, quam Gallos obtinere dictum est, initium capit a flumine Rhodano, continetur Garumna flumine, "
+                     "Oceano, finibus Belgarum, attingit etiam ab Sequanis et Helvetiis flumen Rhenum, vergit ad septentriones. Belgae ab extremis Galliae finibus oriuntur, pertinent ad inferiorem "
+                     "partem fluminis Rheni, spectant in septentrionem et orientem solem. Aquitania a Garumna flumine ad Pyrenaeos montes et eam partem Oceani quae est ad Hispaniam pertinet; spectat "
+                     "inter occasum solis et septentriones.\n"
+                     "Apud Helvetios longe nobilissimus fuit et ditissimus Orgetorix. Is M. Messala, [et P.] M. Pisone consulibus regni cupiditate inductus coniurationem nobilitatis fecit et civitati "
+                     "persuasit ut de finibus suis cum omnibus copiis exirent: perfacile esse, cum virtute omnibus praestarent, totius Galliae imperio potiri. Id hoc facilius iis persuasit, quod undique "
+                     "loci natura Helvetii continentur: una ex parte flumine Rheno latissimo atque altissimo, qui agrum Helvetium a Germanis dividit; altera ex parte monte Iura altissimo, qui est inter "
+                     "Sequanos et Helvetios; tertia lacu Lemanno et flumine Rhodano, qui provinciam nostram ab Helvetiis dividit. His rebus fiebat ut et minus late vagarentur et minus facile finitimis "
+                     "bellum inferre possent; qua ex parte homines bellandi cupidi magno dolore adficiebantur. Pro multitudine autem hominum et pro gloria belli atque fortitudinis angustos se fines "
+                     "habere arbitrabantur, qui in longitudinem milia passuum CCXL, in latitudinem CLXXX patebant.\n"
+                     "His rebus adducti et auctoritate Orgetorigis permoti constituerunt ea quae ad proficiscendum pertinerent comparare, iumentorum et carrorum quam maximum numerum coemere, sementes "
+                     "quam maximas facere, ut in itinere copia frumenti suppeteret, cum proximis civitatibus pacem et amicitiam confirmare. Ad eas res conficiendas biennium sibi satis esse duxerunt; in "
+                     "tertium annum profectionem lege confirmant. Ad eas res conficiendas Orgetorix deligitur. Is sibi legationem ad civitates suscipit. In eo itinere persuadet Castico, Catamantaloedis "
+                     "filio, Sequano, cuius pater regnum in Sequanis multos annos obtinuerat et a senatu populi Romani amicus appellatus erat, ut regnum in civitate sua occuparet, quod pater ante "
+                     "habuerit; itemque Dumnorigi Haeduo, fratri Diviciaci, qui eo tempore principatum in civitate obtinebat ac maxime plebi acceptus erat, ut idem conaretur persuadet eique filiam "
+                     "suam in matrimonium dat. Perfacile factu esse illis probat conata perficere, propterea quod ipse suae civitatis imperium obtenturus esset: non esse dubium quin totius Galliae "
+                     "plurimum Helvetii possent; se suis copiis suoque exercitu illis regna conciliaturum confirmat. Hac oratione adducti inter se fidem et ius iurandum dant et regno occupato per tres "
+                     "potentissimos ac firmissimos populos totius Galliae sese potiri posse sperant.\n"
+                     "Ea res est Helvetiis per indicium enuntiata. Moribus suis Orgetoricem ex vinculis causam dicere coegerunt; damnatum poenam sequi oportebat, ut igni cremaretur. Die constituta "
+                     "causae dictionis Orgetorix ad iudicium omnem suam familiam, ad hominum milia decem, undique coegit, et omnes clientes obaeratosque suos, quorum magnum numerum habebat, eodem "
+                     "conduxit; per eos ne causam diceret se eripuit. Cum civitas ob eam rem incitata armis ius suum exequi conaretur multitudinemque hominum ex agris magistratus cogerent, Orgetorix "
+                     "mortuus est; neque abest suspicio, ut Helvetii arbitrantur, quin ipse sibi mortem consciverit.\n"
+                     "Post eius mortem nihilo minus Helvetii id quod constituerant facere conantur, ut e finibus suis exeant. Ubi iam se ad eam rem paratos esse arbitrati sunt, oppida sua omnia, numero "
+                     "ad duodecim, vicos ad quadringentos, reliqua privata aedificia incendunt; frumentum omne, praeter quod secum portaturi erant, comburunt, ut domum reditionis spe sublata paratiores "
+                     "ad omnia pericula subeunda essent; trium mensum molita cibaria sibi quemque domo efferre iubent. Persuadent Rauracis et Tulingis et Latobrigis finitimis, uti eodem usi consilio "
+                     "oppidis suis vicisque exustis una cum iis proficiscantur, Boiosque, qui trans Rhenum incoluerant et in agrum Noricum transierant Noreiamque oppugnabant, receptos ad se socios sibi "
+                     "adsciscunt.\n"
+                     "Erant omnino itinera duo, quibus itineribus domo exire possent: unum per Sequanos, angustum et difficile, inter montem Iuram et flumen Rhodanum, vix qua singuli carri ducerentur, "
+                     "mons autem altissimus impendebat, ut facile perpauci prohibere possent; alterum per provinciam nostram, multo facilius atque expeditius, propterea quod inter fines Helvetiorum et "
+                     "Allobrogum, qui nuper pacati erant, Rhodanus fluit isque non nullis locis vado transitur. Extremum oppidum Allobrogum est proximumque Helvetiorum finibus Genava. Ex eo oppido "
+                     "pons ad Helvetios pertinet. Allobrogibus sese vel persuasuros, quod nondum bono animo in populum Romanum viderentur, existimabant vel vi coacturos ut per suos fines eos ire "
+                     "paterentur. Omnibus rebus ad profectionem comparatis diem dicunt, qua die ad ripam Rhodani omnes conveniant. Is dies erat a. d. V. Kal. Apr. L. Pisone, A. Gabinio consulibus.\n"
+                     "Caesari cum id nuntiatum esset, eos per provincia nostram iter facere conari, maturat ab urbe proficisci et quam maximis potest itineribus in Galliam ulteriorem contendit et ad "
+                     "Genavam pervenit. Provinciae toti quam maximum potest militum numerum imperat (erat omnino in Gallia ulteriore legio una), pontem, qui erat ad Genavam, iubet rescindi. Ubi de eius "
+                     "aventu Helvetii certiores facti sunt, legatos ad eum mittunt nobilissimos civitatis, cuius legationis Nammeius et Verucloetius principem locum obtinebant, qui dicerent sibi esse "
+                     "in animo sine ullo maleficio iter per provinciam facere, propterea quod aliud iter haberent nullum: rogare ut eius voluntate id sibi facere liceat. Caesar, quod memoria tenebat "
+                     "L. Cassium consulem occisum exercitumque eius ab Helvetiis pulsum et sub iugum missum, concedendum non putabat; neque homines inimico animo, data facultate per provinciam itineris "
+                     "faciundi, temperaturos ab iniuria et maleficio existimabat. Tamen, ut spatium intercedere posset dum milites quos imperaverat convenirent, legatis respondit diem se ad "
+                     "deliberandum sumpturum: si quid vellent, ad Id. April. reverterentur.\n"
+                     "Interea ea legione quam secum habebat militibusque, qui ex provincia convenerant, a lacu Lemanno, qui in flumen Rhodanum influit, ad montem Iuram, qui fines Sequanorum ab "
+                     "Helvetiis dividit, milia passuum XVIIII murum in altitudinem pedum sedecim fossamque perducit. Eo opere perfecto praesidia disponit, castella communit, quo facilius, si se invito "
+                     "transire conentur, prohibere possit. Ubi ea dies quam constituerat cum legatis venit et legati ad eum reverterunt, negat se more et exemplo populi Romani posse iter ulli per "
+                     "provinciam dare et, si vim lacere conentur, prohibiturum ostendit. Helvetii ea spe deiecti navibus iunctis ratibusque compluribus factis, alii vadis Rhodani, qua minima altitudo "
+                     "fluminis erat, non numquam interdiu, saepius noctu si perrumpere possent conati, operis munitione et militum concursu et telis repulsi, hoc conatu destiterunt.\n"
+                     "Relinquebatur una per Sequanos via, qua Sequanis invitis propter angustias ire non poterant. His cum sua sponte persuadere non possent, legatos ad Dumnorigem Haeduum mittunt, ut "
+                     "eo deprecatore a Sequanis impetrarent. Dumnorix gratia et largitione apud Sequanos plurimum poterat et Helvetiis erat amicus, quod ex ea civitate Orgetorigis filiam in matrimonium "
+                     "duxerat, et cupiditate regni adductus novis rebus studebat et quam plurimas civitates suo beneficio habere obstrictas volebat. Itaque rem suscipit et a Sequanis impetrat ut per "
+                     "fines suos Helvetios ire patiantur, obsidesque uti inter sese dent perficit: Sequani, ne itinere Helvetios prohibeant, Helvetii, ut sine maleficio et iniuria transeant.\n"
+                     "Caesari renuntiatur Helvetiis esse in animo per agrum Sequanorum et Haeduorum iter in Santonum fines facere, qui non longe a Tolosatium finibus absunt, quae civitas est in "
+                     "provincia. Id si fieret, intellegebat magno cum periculo provinciae futurum ut homines bellicosos, populi Romani inimicos, locis patentibus maximeque frumentariis finitimos "
+                     "haberet. Ob eas causas ei munitioni quam fecerat T. Labienum legatum praeficit; ipse in Italiam magnis itineribus contendit duasque ibi legiones conscribit et tres, quae circum "
+                     "Aquileiam hiemabant, ex hibernis educit et, qua proximum iter in ulteriorem Galliam per Alpes erat, cum his quinque legionibus ire contendit. Ibi Ceutrones et Graioceli et "
+                     "Caturiges locis superioribus occupatis itinere exercitum prohibere conantur. Compluribus his proeliis pulsis ab Ocelo, quod est oppidum citerioris provinciae extremum, in fines "
+                     "Vocontiorum ulterioris provinciae die septimo pervenit; inde in Allobrogum fines, ab Allobrogibus in Segusiavos exercitum ducit. Hi sunt extra provinciam trans Rhodanum primi.";
+
+std::string caesar_search_string = "Gallia";
+
+// Here is a more complete stress test
+std::string repeated(100000, 'A');
+std::string repeated_search_string = "AAA";
+
+// Test functor that lists all indices in order
+struct kmp_functor
+{
+    void operator()(const size_t& index)
+    {
+        indices.push_back(index);
+    }
+
+    void merge(kmp_functor&& other)
+    {
+        indices.splice(indices.end(), std::move(other.indices));
+    }
+
+    // We use a list for more efficient splicing here.
+    std::list<size_t> indices;
+};
+
+// Inefficient and naive reference implementation of string searching.
+std::list<size_t> string_search(const std::string& haystack, const std::string& needle)
+{
+    std::list<size_t> indices;
+    for (size_t index = 0; index < haystack.size() - needle.size() + 1; ++index)
+    {
+        std::string substring = haystack.substr(index, needle.size());
+        if (substring == needle)
+            indices.push_back(index);
+    }
+    return indices;
+}
+
+// Use a similar technique to parallel_kmp to enable us to easily test all 16 versions.
+#define KMP_IMPL(...) \
+    kmp_functor functor; \
+    do { \
+        auto scheduler = boost::asynchronous::make_shared_scheduler_proxy<boost::asynchronous::threadpool_scheduler<boost::asynchronous::lockfree_queue<>>>(6); \
+        std::future<kmp_functor> fu = boost::asynchronous::post_future( \
+            scheduler, \
+            [] { return boost::asynchronous::parallel_kmp(__VA_ARGS__, kmp_functor {}, 1500, "parallel_kmp", 0); }, \
+            "test_parallel_kmp", \
+            0 \
+        ); \
+        try \
+        { \
+            functor = fu.get(); \
+        } \
+        catch (...) \
+        { \
+            BOOST_FAIL("Unexpected exception."); \
+        } \
+    } while (0)
+
+#define AS_ITER(arg) arg.cbegin(), arg.cend()
+#define AS_RNGE(arg) arg
+#define AS_MOVE(arg) std::move(typename std::decay<decltype(arg)>::type(arg))
+#define AS_CONT(arg) boost::asynchronous::then(boost::asynchronous::parallel_for(std::vector<int>(), [](int){}, 1, "dummy task", 0), [](boost::asynchronous::expected<std::vector<int>> exp) { exp.get(); return arg; })
+
+#define TEST_RUN(haystack, needle, modif_a, modif_b) \
+    do { \
+        auto haystack_copy = haystack; \
+        auto reference = string_search(haystack_copy, needle); \
+        KMP_IMPL(AS_##modif_a(haystack), AS_##modif_b(needle)); \
+        BOOST_CHECK_MESSAGE(functor.indices.size() != 0, "Needle not found in " #haystack); \
+        BOOST_CHECK_MESSAGE(functor.indices == reference, "Result differs from reference implementation for " #haystack); \
+        for (size_t index : functor.indices) \
+            BOOST_CHECK_MESSAGE(haystack_copy.substr(index, needle.size()) == needle, "Got index without match in " #haystack ": " + std::to_string(index)); \
+    } while(0)
+
+#define SINGLE_TEST(name, haystack, needle, modif_a, modif_b) \
+    BOOST_AUTO_TEST_CASE(name) \
+    { \
+        TEST_RUN(haystack, needle, modif_a, modif_b); \
+    }
+
+// Unfortunately, building all the different versions simultaneously also requires way too much RAM.
+// So, we just test a couple combinations to ensure that each element has been tested in each position.
+SINGLE_TEST(test_parallel_kmp_caesar_iter_iter, caesar, caesar_search_string, ITER, ITER)
+SINGLE_TEST(test_parallel_kmp_caesar_rnge_rnge, caesar, caesar_search_string, RNGE, RNGE)
+SINGLE_TEST(test_parallel_kmp_caesar_move_move, caesar, caesar_search_string, MOVE, MOVE)
+SINGLE_TEST(test_parallel_kmp_caesar_cont_cont, caesar, caesar_search_string, CONT, CONT)
+
+SINGLE_TEST(test_parallel_kmp_aaaaaa_iter_move, repeated, repeated_search_string, ITER, MOVE)
+SINGLE_TEST(test_parallel_kmp_aaaaaa_cont_iter, repeated, repeated_search_string, CONT, ITER)
+SINGLE_TEST(test_parallel_kmp_aaaaaa_rnge_cont, repeated, repeated_search_string, RNGE, CONT)
+
+}


### PR DESCRIPTION
`all_of`: Take all the continuations and transform them into a continuations returning a tuple of their results.
`any_of`: Very similar, but returns the result of the first continuation that finishes.
`parallel_kmp`: Efficient substring (or subsequence) search using [Knuth-Morris-Pratt](https://en.wikipedia.org/wiki/Knuth%E2%80%93Morris%E2%80%93Pratt_algorithm).