### PR TITLE
Fix compiler warnings with MSVC 2017/2019

### DIFF
--- a/boost/asynchronous/extensions/asio/asio_scheduler.hpp
+++ b/boost/asynchronous/extensions/asio/asio_scheduler.hpp
@@ -167,7 +167,7 @@ public:
         {
             for (size_t i = 0; i< std::get<1>(v) && (t < m_ioservices.size()) ;++i)
             {
-                boost::asynchronous::detail::processor_bind_task task(std::get<0>(v)+i);
+                boost::asynchronous::detail::processor_bind_task task(static_cast<unsigned int>(std::get<0>(v)+i));
                 job_type job(std::move(task));
                 this->post(std::move(job),t++);
             }

--- a/boost/asynchronous/scheduler/detail/multi_queue_scheduler_policy.hpp
+++ b/boost/asynchronous/scheduler/detail/multi_queue_scheduler_policy.hpp
@@ -45,7 +45,7 @@ public:
         for (typename std::vector<std::shared_ptr<queue_type> >::const_iterator it = m_queues.begin(); it != m_queues.end();++it)
         {
             auto vec = (*it)->get_queue_size();
-            res += std::accumulate(vec.begin(),vec.end(),0,[](std::size_t rhs,std::size_t lhs){return rhs + lhs;});
+            res += std::accumulate(vec.begin(),vec.end(),size_t(0),[](std::size_t rhs,std::size_t lhs){return rhs + lhs;});
         }
         std::vector<std::size_t> res_vec;
         res_vec.push_back(res);

--- a/boost/asynchronous/scheduler/multiqueue_threadpool_scheduler.hpp
+++ b/boost/asynchronous/scheduler/multiqueue_threadpool_scheduler.hpp
@@ -181,7 +181,7 @@ public:
         size_t t = 0;
         for(auto const& v : p)
         {
-            for (size_t i = 0; i< std::get<1>(v) && (t < m_number_of_workers);++i)
+            for (unsigned int i = 0; i< std::get<1>(v) && (t < m_number_of_workers);++i)
             {
                 boost::asynchronous::detail::processor_bind_task task(std::get<0>(v)+i);
                 boost::asynchronous::any_callable job(std::move(task));


### PR DESCRIPTION
Since the warning messages are very long and very frequent, this makes compiling programs that use asynchronous very unpleasant. This commit fixes at least the ones I encountered.
* Fix compiler warnings due to different types (signed/unsigned) with MSVC 2017/2019.
