### PR TITLE
Add register_scheduler to html_formatter_t and basic_formatter

### DIFF
--- a/boost/asynchronous/diagnostics/basic_formatter.hpp
+++ b/boost/asynchronous/diagnostics/basic_formatter.hpp
@@ -127,6 +127,13 @@ public:
         return format(diagnostics.size(), std::move(names), std::move(queue_sizes), std::move(running), std::move(current), std::move(all));
     }
 
+
+    // Registers an additional scheduler with the formatter
+    void register_scheduler(boost::asynchronous::scheduler_interface interface)
+    {
+        m_interfaces.push_back(std::move(interface));
+    }
+
     // Clearing data
 
     void clear_schedulers() {

--- a/boost/asynchronous/diagnostics/html_formatter.hpp
+++ b/boost/asynchronous/diagnostics/html_formatter.hpp
@@ -1406,6 +1406,7 @@ public:
 
     // Enable use of basic_formatter's diagnostics retrieval
     using boost::asynchronous::basic_formatter<Current, All>::format;
+    using boost::asynchronous::basic_formatter<Current, All>::register_scheduler;
 
     // Constructors
 


### PR DESCRIPTION
Implements register_scheduler as required in `formatter.hpp:25` for `basic_formatter` and `html_formatter`